### PR TITLE
fix ping stuck at 0 on performance screen

### DIFF
--- a/app/src/main/java/com/framex/app/metrics/Monitors.kt
+++ b/app/src/main/java/com/framex/app/metrics/Monitors.kt
@@ -410,6 +410,13 @@ class ThermalMonitor @Inject constructor(
 class PingMonitor @Inject constructor(
     private val shizukuManager: ShizukuManager
 ) {
+    companion object {
+        // ICMP echo has near-zero cost, but Shizuku shell round-trips + the child
+        // "ping" process still cost a bit of CPU/battery. 20s keeps the reading
+        // fresh without polling faster than a human perceives latency changing.
+        private const val POLL_INTERVAL_MS = 20_000L
+    }
+
     val ping: Flow<Int> = flow {
         while (true) {
             val output = if (shizukuManager.isShizukuAvailable.value && shizukuManager.hasPermission.value) {
@@ -429,7 +436,7 @@ class PingMonitor @Inject constructor(
                     ?.roundToInt() ?: 0
             } else 0
             emit(pingMs)
-            delay(3000)
+            delay(POLL_INTERVAL_MS)
         }
     }
 

--- a/app/src/main/java/com/framex/app/ui/screens/PerformanceScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/PerformanceScreen.kt
@@ -107,9 +107,11 @@ class PerformanceViewModel @Inject constructor(
 
     init {
         loadUserApps()
-        // Keep CPU/RAM gauges on this screen live regardless of the user's saved
+        // Keep CPU/RAM/PING live on this screen regardless of the user's saved
         // overlay toggle — via a transient override, not by mutating their setting.
-        metricsEngine.setScreenOverrideModules(setOf("cpu", "ram"))
+        // "ping" must be included here or PingMonitor never starts polling, and
+        // the PING card reads MetricsState's default (0) forever.
+        metricsEngine.setScreenOverrideModules(setOf("cpu", "ram", "ping"))
     }
 
     override fun onCleared() {
@@ -1224,6 +1226,11 @@ fun PerformanceScreen(
                             val pingRes = viewModel.measureNetworkLatency()
                             isOptimizingNet = false
                             showPingResult = true
+                            // Reflect the real measurement on the PING card itself.
+                            // A null result means the network probe genuinely failed
+                            // to reach 8.8.8.8 — treat it the same as the live monitor's
+                            // "no signal" state (0) rather than leaving the stale value up.
+                            activeLatencyDiagnostic = pingRes ?: 0
                             showRamSuccessBanner = pingRes?.let {
                                 "Latency check complete: $it ms"
                             } ?: "Latency check failed: network unreachable"


### PR DESCRIPTION
fixes #12

ping module override was missing from the screen init so PingMonitor never actually started polling here. also the swipe-to-check-ping result was getting thrown away, it only showed up in the toast and never updated the card itself. wired both up properly and bumped the poll interval to 20s since 3s was way more aggressive than it needed to be for a shizuku round trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the Performance screen’s Ping monitoring by including it in live metrics updates.
  - Updated the Ping dashboard with the latest latency measurement after a swipe-to-check action.
  - Adjusted Ping polling to run at a consistent 20-second interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->