### PR TITLE
Add Thermal Diagnostics: full CPU/GPU/SKIN breakdown, FPS correlation graph, session recording

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -102,6 +102,17 @@
             android:exported="true"
             android:permission="android.permission.INTERACT_ACROSS_USERS_FULL" />
 
+        <!-- Shares exported session-log CSVs via a content:// URI (share sheet). -->
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
+
     </application>
 
 </manifest>

--- a/app/src/main/java/com/framex/app/metrics/MetricsEngine.kt
+++ b/app/src/main/java/com/framex/app/metrics/MetricsEngine.kt
@@ -26,7 +26,12 @@ data class MetricsState(
     val networkRxKbps: Float = 0f,
     val networkTxKbps: Float = 0f,
     val pingMs: Int = 0,
-    val isThermalThrottling: Boolean = false
+    // Full thermal breakdown — see ThermalMonitor.ThermalState for field meaning.
+    val thermalCpuC: Float = 0f,
+    val thermalGpuC: Float = 0f,
+    val thermalNpuC: Float = 0f,
+    val thermalSkinC: Float = 0f,
+    val thermalStatus: Int = 0
 )
 
 @Singleton
@@ -47,6 +52,15 @@ class MetricsEngine @Inject constructor(
     // Used by the Dashboard chart to show a real sparkline from recent samples.
     private val _fpsHistory = MutableStateFlow<List<Int>>(emptyList())
     val fpsHistory: StateFlow<List<Int>> = _fpsHistory.asStateFlow()
+
+    // Timestamped snapshot of the full metrics state, appended every ~1s regardless
+    // of which modules are enabled for the overlay. This is the source of truth for
+    // the "what caused the frame drop" correlation graph and for session log export —
+    // both need every metric on the same timeline, not just what the user chose to
+    // display on-screen. Capped to avoid unbounded memory growth during long sessions.
+    data class MetricsSnapshot(val timestampMs: Long, val state: MetricsState)
+    private val _snapshotHistory = MutableStateFlow<List<MetricsSnapshot>>(emptyList())
+    val snapshotHistory: StateFlow<List<MetricsSnapshot>> = _snapshotHistory.asStateFlow()
 
     // SupervisorJob: one failing monitor coroutine never cancels the others.
     private val engineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
@@ -76,6 +90,14 @@ class MetricsEngine @Inject constructor(
                     if (d.size > 60) d.removeFirst()
                 }
                 _fpsHistory.value = next.toList()
+
+                // Snapshot the full state at this tick for logging/correlation, capped
+                // at MAX_SNAPSHOTS (~1hr at 1s cadence) so long sessions don't grow unbounded.
+                val snapshots = ArrayDeque(_snapshotHistory.value).also { d ->
+                    d.addLast(MetricsSnapshot(System.currentTimeMillis(), _metricsState.value))
+                    if (d.size > MAX_SNAPSHOTS) d.removeFirst()
+                }
+                _snapshotHistory.value = snapshots.toList()
             }
         }
 
@@ -133,8 +155,14 @@ class MetricsEngine @Inject constructor(
                     }
                 }
                 toggleModule("thermal", enabled) {
-                    thermalMonitor.isThrottling.collect {
-                        _metricsState.value = _metricsState.value.copy(isThermalThrottling = it)
+                    thermalMonitor.thermalState.collect { t ->
+                        _metricsState.value = _metricsState.value.copy(
+                            thermalCpuC = t.cpuC,
+                            thermalGpuC = t.gpuC,
+                            thermalNpuC = t.npuC,
+                            thermalSkinC = t.skinC,
+                            thermalStatus = t.status
+                        )
                     }
                 }
                 toggleModule("ping", enabled) {
@@ -165,10 +193,19 @@ class MetricsEngine @Inject constructor(
                 "ram"     -> _metricsState.value.copy(ramUsedGb = 0f, ramTotalGb = 0f)
                 "net"     -> _metricsState.value.copy(networkRxKbps = 0f, networkTxKbps = 0f)
                 "temp"    -> _metricsState.value.copy(batteryTempC = 0f)
-                "thermal" -> _metricsState.value.copy(isThermalThrottling = false)
+                "thermal" -> _metricsState.value.copy(
+                    thermalCpuC = 0f, thermalGpuC = 0f, thermalNpuC = 0f,
+                    thermalSkinC = 0f, thermalStatus = 0
+                )
                 "ping"    -> _metricsState.value.copy(pingMs = 0)
                 else      -> _metricsState.value
             }
         }
+    }
+
+    companion object {
+        // ~1 hour of history at 1s cadence. Long enough for a full gaming session's
+        // worth of correlation data without holding unbounded memory.
+        private const val MAX_SNAPSHOTS = 3600
     }
 }

--- a/app/src/main/java/com/framex/app/metrics/MetricsEngine.kt
+++ b/app/src/main/java/com/framex/app/metrics/MetricsEngine.kt
@@ -15,6 +15,7 @@ import javax.inject.Singleton
 
 data class MetricsState(
     val fps: Int = 0,
+    val jankyFrames: Int = 0,
     val cpuMhz: Int = 0,
     val cpuPercentage: Int? = null,
     val cpuClusterUltraMhz: Int = 0,
@@ -31,7 +32,11 @@ data class MetricsState(
     val thermalGpuC: Float = 0f,
     val thermalNpuC: Float = 0f,
     val thermalSkinC: Float = 0f,
-    val thermalStatus: Int = 0
+    val thermalStatus: Int = 0,
+    // Busiest process at this tick (see TopProcessMonitor) — names the likely
+    // culprit when a frame drop isn't explained by thermal or frequency alone.
+    val topProcessName: String? = null,
+    val topProcessCpuPercent: Float = 0f
 )
 
 @Singleton
@@ -43,6 +48,7 @@ class MetricsEngine @Inject constructor(
     private val batteryMonitor: BatteryMonitor,
     private val thermalMonitor: ThermalMonitor,
     private val pingMonitor: PingMonitor,
+    private val topProcessMonitor: TopProcessMonitor,
     private val settingsRepository: SettingsRepository
 ) {
     private val _metricsState = MutableStateFlow(MetricsState())
@@ -67,26 +73,35 @@ class MetricsEngine @Inject constructor(
     private val moduleJobs = mutableMapOf<String, Job>()
 
     // Transient, NOT persisted, NOT shown in the overlay toggle UI.
-    // Lets a screen (e.g. PerformanceScreen) request a monitor stay live while it's
-    // visible, without mutating the user's saved overlay module preference.
+    // Multiple independent callers (a screen wanting live readings, a recording
+    // session wanting the full diagnostic set) can each hold their own named
+    // request here without one clobbering the other when either releases its set.
     // The overlay (OverlayManager/AppearanceScreen) reads settingsRepository.enabledModules
     // directly, so anything added here never affects what the overlay displays.
-    private val _screenOverrideModules = MutableStateFlow<Set<String>>(emptySet())
+    private val _screenOverrideRequests = MutableStateFlow<Map<String, Set<String>>>(emptyMap())
+    private val screenOverrideModules = kotlinx.coroutines.flow.MutableStateFlow<Set<String>>(emptySet())
 
-    /** Request that [modules] keep polling regardless of the persisted overlay toggle.
-     *  Pass emptySet() to release the request (e.g. when leaving the screen). */
-    fun setScreenOverrideModules(modules: Set<String>) {
-        _screenOverrideModules.value = modules
+    /** Request that [modules] keep polling regardless of the persisted overlay toggle,
+     *  under [requesterKey] so unrelated requesters don't clobber each other.
+     *  Pass emptySet() to release this requester's request. */
+    fun setScreenOverrideModules(modules: Set<String>, requesterKey: String = "default") {
+        val next = if (modules.isEmpty()) {
+            _screenOverrideRequests.value - requesterKey
+        } else {
+            _screenOverrideRequests.value + (requesterKey to modules)
+        }
+        _screenOverrideRequests.value = next
+        screenOverrideModules.value = next.values.flatten().toSet()
     }
 
     init {
         // FPS always runs — it is the core metric and has near-zero overhead.
         engineScope.launch {
-            fpsMonitor.framesPerSecond.collect { fps ->
-                _metricsState.value = _metricsState.value.copy(fps = fps)
+            fpsMonitor.fpsState.collect { state ->
+                _metricsState.value = _metricsState.value.copy(fps = state.fps, jankyFrames = state.jankyFrames)
                 // Append to rolling history, capped at 60 entries.
                 val next = ArrayDeque(_fpsHistory.value).also { d ->
-                    d.addLast(fps)
+                    d.addLast(state.fps)
                     if (d.size > 60) d.removeFirst()
                 }
                 _fpsHistory.value = next.toList()
@@ -102,14 +117,14 @@ class MetricsEngine @Inject constructor(
         }
 
         // All other monitors only run while their module toggle is enabled by the user
-        // (settingsRepository.enabledModules) OR temporarily requested by a screen
-        // (_screenOverrideModules). The overlay only ever looks at the former, so a
+        // (settingsRepository.enabledModules) OR temporarily requested by a screen/recording
+        // (screenOverrideModules). The overlay only ever looks at the former, so a
         // screen override never changes what the overlay shows — only what gets measured.
         // This means zero polling happens for disabled modules — no wasted CPU, battery, or Shizuku calls.
         engineScope.launch {
             combine(
                 settingsRepository.enabledModules,
-                _screenOverrideModules
+                screenOverrideModules
             ) { persisted, override -> persisted + override }
                 .collect { enabled ->
                 toggleModule("cpu", enabled) {
@@ -170,6 +185,14 @@ class MetricsEngine @Inject constructor(
                         _metricsState.value = _metricsState.value.copy(pingMs = it)
                     }
                 }
+                toggleModule("top_process", enabled) {
+                    topProcessMonitor.topProcess.collect { top ->
+                        _metricsState.value = _metricsState.value.copy(
+                            topProcessName = top?.name,
+                            topProcessCpuPercent = top?.cpuPercent ?: 0f
+                        )
+                    }
+                }
             }
         }
     }
@@ -198,6 +221,7 @@ class MetricsEngine @Inject constructor(
                     thermalSkinC = 0f, thermalStatus = 0
                 )
                 "ping"    -> _metricsState.value.copy(pingMs = 0)
+                "top_process" -> _metricsState.value.copy(topProcessName = null, topProcessCpuPercent = 0f)
                 else      -> _metricsState.value
             }
         }

--- a/app/src/main/java/com/framex/app/metrics/Monitors.kt
+++ b/app/src/main/java/com/framex/app/metrics/Monitors.kt
@@ -111,10 +111,15 @@ class FpsMonitor @Inject constructor(
                             ?.toInt()
                             ?: 0
 
-                        // "missedFrameCount" is SurfaceFlinger's own tally of frames that
-                        // missed their intended present deadline within this window — the
-                        // direct signal for stutter/jank independent of the FPS mean.
-                        val janky = Regex("missedFrameCount\\s*=\\s*([0-9]+)")
+                        // The real SurfaceFlinger --timestats field is "missedFrames"
+                        // (confirmed against AOSP source: TimeStatsHelper.cpp formats it as
+                        // "missedFrames = %d\n"). An earlier version of this code looked for
+                        // "missedFrameCount", which does not exist in the actual dump — that
+                        // typo is why jankyFrames always read 0. missedFrames is SurfaceFlinger's
+                        // own count of frames that missed their intended present deadline in
+                        // this accumulation window — the direct stutter signal, independent of
+                        // whatever the window's averageFPS mean happens to be.
+                        val janky = Regex("missedFrames\\s*=\\s*([0-9]+)")
                             .find(output)
                             ?.groupValues?.get(1)
                             ?.toIntOrNull()

--- a/app/src/main/java/com/framex/app/metrics/Monitors.kt
+++ b/app/src/main/java/com/framex/app/metrics/Monitors.kt
@@ -60,6 +60,13 @@ class FpsMonitor @Inject constructor(
     @ApplicationContext private val context: Context,
     private val shizukuManager: ShizukuManager
 ) {
+    // fps: rolling averageFPS (existing behavior, unchanged).
+    // jankyFrames: frames counted as janky in the CURRENT accumulation window from
+    // the same `--timestats -dump` call — explains "FPS reads fine but feels laggy":
+    // averageFPS is a mean over the window, so irregular/stuttering frame delivery
+    // can still average out to a normal-looking number while jankyFrames stays high.
+    data class FpsState(val fps: Int, val jankyFrames: Int)
+
     // Exact approach decoded from PerfStats smali (OverlayService$FPSMonitor.smali):
     //
     // TIMING (from smali constants 0xbb8=3000, 0x3e8=1000):
@@ -74,7 +81,7 @@ class FpsMonitor @Inject constructor(
     //
     // HOLD LAST KNOWN: if a dump returns 0 (e.g. right after clear), keep showing
     //   the last real value instead of flashing 0. PerfStats does the same via Handler.
-    val framesPerSecond: Flow<Int> = flow {
+    val fpsState: Flow<FpsState> = flow {
         var initialized = false
         var lastKnownFps = 0
 
@@ -104,9 +111,18 @@ class FpsMonitor @Inject constructor(
                             ?.toInt()
                             ?: 0
 
+                        // "missedFrameCount" is SurfaceFlinger's own tally of frames that
+                        // missed their intended present deadline within this window — the
+                        // direct signal for stutter/jank independent of the FPS mean.
+                        val janky = Regex("missedFrameCount\\s*=\\s*([0-9]+)")
+                            .find(output)
+                            ?.groupValues?.get(1)
+                            ?.toIntOrNull()
+                            ?: 0
+
                         // Step 2: show result — hold last known if dump returned nothing
                         if (parsed > 0) lastKnownFps = parsed
-                        emit(lastKnownFps)
+                        emit(FpsState(lastKnownFps, janky))
 
                         // Step 3: PerfStats exact clear logic (smali: rem-long % 3000 < 1000).
                         // Only clear during the first 1000ms of each 3000ms wall-clock cycle.
@@ -118,12 +134,12 @@ class FpsMonitor @Inject constructor(
                         }
                     }
                 } catch (e: Exception) {
-                    emit(lastKnownFps) // hold last known; never flash 0 on transient error
+                    emit(FpsState(lastKnownFps, 0)) // hold last known; never flash 0 on transient error
                 }
             } else {
                 initialized = false
                 lastKnownFps = 0
-                emit(0)
+                emit(FpsState(0, 0))
             }
             delay(1000)
         }
@@ -522,5 +538,51 @@ class PingMonitor @Inject constructor(
         } catch (e: Exception) {
             ""
         }
+    }
+}
+
+@Singleton
+class TopProcessMonitor @Inject constructor(
+    private val shizukuManager: ShizukuManager
+) {
+    // Answers "which process was busy at the moment FPS dropped" — a temperature
+    // graph only shows thermal was NOT the cause; this is what actually names the
+    // culprit (a vendor daemon, a sync job, etc.) when a drop isn't thermal.
+    data class TopProcess(val name: String, val cpuPercent: Float)
+
+    // `dumpsys cpuinfo` header lines look like:
+    //   23% 1234/com.example.app: 15% user + 8% kernel
+    // The leading percentage is that process's share of a single core's capacity,
+    // already sorted busiest-first by the system service — no extra sorting needed.
+    private val lineRegex = Regex("^\\s*([0-9.]+)%\\s+\\d+/([^:]+):")
+
+    val topProcess: Flow<TopProcess?> = flow {
+        while (true) {
+            val shizukuReady = shizukuManager.isShizukuAvailable.value &&
+                    shizukuManager.hasPermission.value
+
+            val result = if (shizukuReady) {
+                try {
+                    parseTop(shizukuManager.executeCommand("dumpsys cpuinfo"))
+                } catch (e: Exception) {
+                    null
+                }
+            } else null
+
+            emit(result)
+            delay(1000)
+        }
+    }
+
+    private fun parseTop(output: String): TopProcess? {
+        for (line in output.lineSequence()) {
+            val match = lineRegex.find(line) ?: continue
+            val pct = match.groupValues[1].toFloatOrNull() ?: continue
+            val name = match.groupValues[2].trim()
+            // Skip the aggregate "TOTAL" line — we want the top real process.
+            if (name.equals("TOTAL", ignoreCase = true)) continue
+            return TopProcess(name, pct)
+        }
+        return null
     }
 }

--- a/app/src/main/java/com/framex/app/metrics/Monitors.kt
+++ b/app/src/main/java/com/framex/app/metrics/Monitors.kt
@@ -390,19 +390,94 @@ class BatteryMonitor @Inject constructor(
 
 @Singleton
 class ThermalMonitor @Inject constructor(
-    @ApplicationContext private val context: Context
+    @ApplicationContext private val context: Context,
+    private val shizukuManager: ShizukuManager
 ) {
-    val isThrottling: Flow<Boolean> = flow {
+    // Full breakdown from `dumpsys thermalservice`. This is the same data source
+    // Android's own throttling decisions are based on, so it explains WHY frames
+    // drop, not just THAT they drop. Reading it needs no special permission beyond
+    // normal shell (works via Shizuku or even plain adb) since it goes through the
+    // ThermalService binder call, not raw /sys reads (which are often root-gated
+    // on OEM builds — e.g. thermal_zone*/temp is root-only on some Vivo firmware).
+    data class ThermalState(
+        val cpuC: Float = 0f,
+        val gpuC: Float = 0f,
+        val npuC: Float = 0f,
+        val skinC: Float = 0f,
+        val batteryC: Float = 0f,
+        // Android thermal status: 0=NONE 1=LIGHT 2=MODERATE 3=SEVERE 4=CRITICAL 5=EMERGENCY 6=SHUTDOWN
+        val status: Int = 0
+    ) {
+        val statusLabel: String get() = when (status) {
+            0 -> "NONE"; 1 -> "LIGHT"; 2 -> "MODERATE"; 3 -> "SEVERE"
+            4 -> "CRITICAL"; 5 -> "EMERGENCY"; 6 -> "SHUTDOWN"; else -> "?"
+        }
+    }
+
+    // "Current temperatures from HAL:" block looks like:
+    //   Temperature{mValue=62.895, mType=0, mName=CPU, mStatus=0}
+    // mType per Android's Temperature.java: 0=CPU 1=GPU 2=BATTERY 3=SKIN 5=POWER_AMPLIFIER 9=NPU
+    private val entryRegex = Regex(
+        "Temperature\\{mValue=(-?[0-9.]+),\\s*mType=(\\d+),\\s*mName=([A-Z_]+)"
+    )
+
+    val thermalState: Flow<ThermalState> = flow {
         val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
         while (true) {
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                val status = powerManager.currentThermalStatus
-                emit(status >= PowerManager.THERMAL_STATUS_SEVERE)
+            val shizukuReady = shizukuManager.isShizukuAvailable.value &&
+                    shizukuManager.hasPermission.value
+
+            val state = if (shizukuReady) {
+                try {
+                    val output = shizukuManager.executeCommand("dumpsys thermalservice")
+                    parseThermalService(output) ?: fallbackState(powerManager)
+                } catch (e: Exception) {
+                    fallbackState(powerManager)
+                }
             } else {
-                emit(false)
+                fallbackState(powerManager)
             }
-            delay(5000)
+            emit(state)
+            delay(1000)
         }
+    }
+
+    private fun parseThermalService(output: String): ThermalState? {
+        if (output.isBlank()) return null
+
+        // Prefer the "Current temperatures from HAL:" section (live values) over
+        // "Cached temperatures:" (may be briefly stale right after a status change).
+        val halSection = output.substringAfter("Current temperatures from HAL:", "")
+            .substringBefore("Current cooling devices")
+        val section = halSection.ifBlank { output }
+
+        var cpu = 0f; var gpu = 0f; var npu = 0f; var skin = 0f; var battery = 0f
+        var found = false
+        entryRegex.findAll(section).forEach { match ->
+            val value = match.groupValues[1].toFloatOrNull() ?: return@forEach
+            val type = match.groupValues[2].toIntOrNull() ?: return@forEach
+            found = true
+            when (type) {
+                0 -> cpu = value
+                1 -> gpu = value
+                2 -> battery = value
+                3 -> skin = value
+                9 -> npu = value
+            }
+        }
+        if (!found) return null
+
+        val status = Regex("Thermal Status:\\s*(\\d+)")
+            .find(output)?.groupValues?.get(1)?.toIntOrNull() ?: 0
+
+        return ThermalState(cpuC = cpu, gpuC = gpu, npuC = npu, skinC = skin, batteryC = battery, status = status)
+    }
+
+    private fun fallbackState(powerManager: PowerManager): ThermalState {
+        val status = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            powerManager.currentThermalStatus
+        } else 0
+        return ThermalState(status = status)
     }
 }
 

--- a/app/src/main/java/com/framex/app/metrics/SessionLogger.kt
+++ b/app/src/main/java/com/framex/app/metrics/SessionLogger.kt
@@ -1,0 +1,105 @@
+package com.framex.app.metrics
+
+import android.content.Context
+import android.content.Intent
+import androidx.core.content.FileProvider
+import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import java.io.File
+import java.text.SimpleDateFormat
+import java.util.Locale
+import javax.inject.Inject
+import javax.inject.Singleton
+
+/**
+ * Records MetricsEngine's snapshot history to a CSV file that the user can share —
+ * e.g. to attach to a bug report, or to visually correlate exactly which metric
+ * (thermal status, a CPU frequency dip, RAM pressure, etc.) lines up with an FPS
+ * drop at a specific second during a gaming session.
+ *
+ * This is intentionally decoupled from MetricsEngine's *display* state (the overlay
+ * toggle set) — recording captures the FULL snapshot history regardless of which
+ * modules the user has visible on-screen, since the cause of a drop might be a
+ * metric they didn't bother enabling in the overlay.
+ */
+@Singleton
+class SessionLogger @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val metricsEngine: MetricsEngine
+) {
+    private val _isRecording = MutableStateFlow(false)
+    val isRecording: StateFlow<Boolean> = _isRecording.asStateFlow()
+
+    // Snapshot index (into metricsEngine.snapshotHistory) marking where this
+    // recording session started, so exporting doesn't include earlier history
+    // that predates the user pressing "Start".
+    private var recordingStartIndex = 0
+
+    private val _lastExportedFile = MutableStateFlow<File?>(null)
+    val lastExportedFile: StateFlow<File?> = _lastExportedFile.asStateFlow()
+
+    fun startRecording() {
+        recordingStartIndex = metricsEngine.snapshotHistory.value.size
+        _isRecording.value = true
+    }
+
+    fun stopRecording() {
+        _isRecording.value = false
+    }
+
+    /** Writes the recorded window (start → now) to a CSV in app-private storage
+     *  and returns a content:// URI ready to hand to a share Intent. Returns null
+     *  if there's nothing to export. */
+    fun exportToFile(): File? {
+        val all = metricsEngine.snapshotHistory.value
+        val window = if (recordingStartIndex in all.indices) all.subList(recordingStartIndex, all.size) else all
+        if (window.isEmpty()) return null
+
+        val dir = File(context.filesDir, "session_logs").apply { mkdirs() }
+        val name = "framex_session_${SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(System.currentTimeMillis())}.csv"
+        val file = File(dir, name)
+
+        file.bufferedWriter().use { writer ->
+            writer.write(
+                "timestamp,fps,cpu_mhz,cpu_percent,cpu_cluster_eff_mhz,cpu_cluster_perf_mhz,cpu_cluster_ultra_mhz," +
+                    "ram_used_gb,ram_total_gb,battery_temp_c,network_rx_kbps,network_tx_kbps,ping_ms," +
+                    "thermal_cpu_c,thermal_gpu_c,thermal_npu_c,thermal_skin_c,thermal_status\n"
+            )
+            val fmt = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
+            for (snap in window) {
+                val s = snap.state
+                writer.write(
+                    "${fmt.format(snap.timestampMs)},${s.fps},${s.cpuMhz},${s.cpuPercentage ?: ""}," +
+                        "${s.cpuClusterEffMhz},${s.cpuClusterPerfMhz},${s.cpuClusterUltraMhz}," +
+                        "${s.ramUsedGb},${s.ramTotalGb},${s.batteryTempC},${s.networkRxKbps},${s.networkTxKbps},${s.pingMs}," +
+                        "${s.thermalCpuC},${s.thermalGpuC},${s.thermalNpuC},${s.thermalSkinC},${s.thermalStatus}\n"
+                )
+            }
+        }
+
+        _lastExportedFile.value = file
+        return file
+    }
+
+    /** Builds a share Intent for the given file via FileProvider. Caller starts it
+     *  with startActivity(Intent.createChooser(...)). */
+    fun buildShareIntent(file: File): Intent {
+        val uri = FileProvider.getUriForFile(context, "${context.packageName}.fileprovider", file)
+        return Intent(Intent.ACTION_SEND).apply {
+            type = "text/csv"
+            putExtra(Intent.EXTRA_STREAM, uri)
+            putExtra(Intent.EXTRA_SUBJECT, "FrameX session log — ${file.name}")
+            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+        }
+    }
+
+    /** Number of samples currently held in the active recording window — lets the UI
+     *  show a live "N seconds recorded" counter without exporting. */
+    fun currentRecordingCount(): Int {
+        if (!_isRecording.value) return 0
+        val all = metricsEngine.snapshotHistory.value
+        return (all.size - recordingStartIndex).coerceAtLeast(0)
+    }
+}

--- a/app/src/main/java/com/framex/app/metrics/SessionLogger.kt
+++ b/app/src/main/java/com/framex/app/metrics/SessionLogger.kt
@@ -40,12 +40,20 @@ class SessionLogger @Inject constructor(
     private val _lastExportedFile = MutableStateFlow<File?>(null)
     val lastExportedFile: StateFlow<File?> = _lastExportedFile.asStateFlow()
 
+    // Recording needs every diagnostic signal on the timeline, not just whatever the
+    // user happened to enable on their overlay — so it force-enables the full set via
+    // MetricsEngine's screen-override mechanism (additive, never touches the user's
+    // saved overlay toggles) for the duration of the recording only.
+    private val recordingModules = setOf("thermal", "temp", "cpu", "cpu_cluster", "ram", "top_process")
+
     fun startRecording() {
         recordingStartIndex = metricsEngine.snapshotHistory.value.size
+        metricsEngine.setScreenOverrideModules(recordingModules, requesterKey = "session_logger")
         _isRecording.value = true
     }
 
     fun stopRecording() {
+        metricsEngine.setScreenOverrideModules(emptySet(), requesterKey = "session_logger")
         _isRecording.value = false
     }
 
@@ -63,18 +71,20 @@ class SessionLogger @Inject constructor(
 
         file.bufferedWriter().use { writer ->
             writer.write(
-                "timestamp,fps,cpu_mhz,cpu_percent,cpu_cluster_eff_mhz,cpu_cluster_perf_mhz,cpu_cluster_ultra_mhz," +
+                "timestamp,fps,janky_frames,cpu_mhz,cpu_percent,cpu_cluster_eff_mhz,cpu_cluster_perf_mhz,cpu_cluster_ultra_mhz," +
                     "ram_used_gb,ram_total_gb,battery_temp_c,network_rx_kbps,network_tx_kbps,ping_ms," +
-                    "thermal_cpu_c,thermal_gpu_c,thermal_npu_c,thermal_skin_c,thermal_status\n"
+                    "thermal_cpu_c,thermal_gpu_c,thermal_npu_c,thermal_skin_c,thermal_status," +
+                    "top_process,top_process_cpu_percent\n"
             )
             val fmt = SimpleDateFormat("yyyy-MM-dd HH:mm:ss", Locale.US)
             for (snap in window) {
                 val s = snap.state
                 writer.write(
-                    "${fmt.format(snap.timestampMs)},${s.fps},${s.cpuMhz},${s.cpuPercentage ?: ""}," +
+                    "${fmt.format(snap.timestampMs)},${s.fps},${s.jankyFrames},${s.cpuMhz},${s.cpuPercentage ?: ""}," +
                         "${s.cpuClusterEffMhz},${s.cpuClusterPerfMhz},${s.cpuClusterUltraMhz}," +
                         "${s.ramUsedGb},${s.ramTotalGb},${s.batteryTempC},${s.networkRxKbps},${s.networkTxKbps},${s.pingMs}," +
-                        "${s.thermalCpuC},${s.thermalGpuC},${s.thermalNpuC},${s.thermalSkinC},${s.thermalStatus}\n"
+                        "${s.thermalCpuC},${s.thermalGpuC},${s.thermalNpuC},${s.thermalSkinC},${s.thermalStatus}," +
+                        "${s.topProcessName ?: ""},${s.topProcessCpuPercent}\n"
                 )
             }
         }

--- a/app/src/main/java/com/framex/app/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/framex/app/overlay/OverlayManager.kt
@@ -286,6 +286,11 @@ fun OverlayContent(
         Triple("cpu_cluster", "CPU Clusters", "U:${metricsState.cpuClusterUltraMhz} P:${metricsState.cpuClusterPerfMhz} E:${metricsState.cpuClusterEffMhz}") to Icons.Default.Memory,
         Triple("ram", "RAM", String.format("%.1f GB", metricsState.ramUsedGb)) to Icons.Default.DeveloperBoard,
         Triple("temp", "TEMP", String.format("%.1f°C", metricsState.batteryTempC)) to Icons.Default.DeviceThermostat,
+        Triple(
+            "thermal",
+            "THERMAL",
+            String.format("%.0f°C %s", metricsState.thermalCpuC, thermalStatusShortLabel(metricsState.thermalStatus))
+        ) to Icons.Default.LocalFireDepartment,
         Triple("net", "NET", if (metricsState.networkRxKbps > 1024) String.format("%.1f MB/s", (metricsState.networkRxKbps + metricsState.networkTxKbps) / 1024f) else String.format("%.0f KB/s", metricsState.networkRxKbps + metricsState.networkTxKbps)) to Icons.Default.NetworkCheck
     )
     
@@ -387,6 +392,13 @@ fun OverlayContent(
             }
         }
     }
+}
+
+// Short label for the overlay's compact/minimal display — full names are used in
+// the Performance/detail screens where there's room to show "MODERATE" in full.
+private fun thermalStatusShortLabel(status: Int): String = when (status) {
+    0 -> "OK"; 1 -> "OK"; 2 -> "WARM"; 3 -> "HOT"
+    4 -> "CRIT"; 5, 6 -> "!!!"; else -> "?"
 }
 
 private class OverlayLifecycleOwner : SavedStateRegistryOwner, ViewModelStoreOwner {

--- a/app/src/main/java/com/framex/app/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/framex/app/ui/navigation/NavGraph.kt
@@ -13,6 +13,7 @@ import com.framex.app.ui.screens.OverlayCustomizationScreen
 import com.framex.app.ui.screens.PerformanceScreen
 import com.framex.app.ui.screens.PermissionsScreen
 import com.framex.app.ui.screens.SplashScreen
+import com.framex.app.ui.screens.ThermalDiagnosticsScreen
 
 sealed class Screen(val route: String) {
     object Splash : Screen("splash")
@@ -23,6 +24,7 @@ sealed class Screen(val route: String) {
     object Permissions : Screen("permissions")
     object About : Screen("about")
     object Performance : Screen("performance")
+    object ThermalDiagnostics : Screen("thermal_diagnostics")
 }
 
 @Composable
@@ -51,7 +53,8 @@ fun FrameXNavGraph(
                 onNavigateToOverlayCustomization = { navController.navigate(Screen.OverlayCustomization.route) },
                 onNavigateToPermissions = { navController.navigate(Screen.Permissions.route) },
                 onNavigateToAbout = { navController.navigate(Screen.About.route) },
-                onNavigateToPerformance = { navController.navigate(Screen.Performance.route) }
+                onNavigateToPerformance = { navController.navigate(Screen.Performance.route) },
+                onNavigateToThermalDiagnostics = { navController.navigate(Screen.ThermalDiagnostics.route) }
             )
         }
         composable(Screen.Appearance.route) {
@@ -68,6 +71,9 @@ fun FrameXNavGraph(
         }
         composable(Screen.Performance.route) {
             PerformanceScreen(onNavigateBack = { navController.popBackStack() })
+        }
+        composable(Screen.ThermalDiagnostics.route) {
+            ThermalDiagnosticsScreen(onNavigateBack = { navController.popBackStack() })
         }
     }
 }

--- a/app/src/main/java/com/framex/app/ui/screens/DashboardScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/DashboardScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bolt
 import androidx.compose.material.icons.filled.DashboardCustomize
+import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.Palette
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Settings
@@ -61,6 +62,7 @@ fun DashboardScreen(
     onNavigateToPermissions: () -> Unit,
     onNavigateToAbout: () -> Unit,
     onNavigateToPerformance: () -> Unit,
+    onNavigateToThermalDiagnostics: () -> Unit,
     viewModel: PermissionsViewModel = androidx.hilt.navigation.compose.hiltViewModel(),
     dashboardViewModel: DashboardViewModel = androidx.hilt.navigation.compose.hiltViewModel()
 ) {
@@ -346,6 +348,24 @@ fun DashboardScreen(
                     onClick = onNavigateToPermissions,
                     modifier = Modifier.weight(1f).fillMaxHeight(),
                     icon = { Text("ADB", color = if (isShizukuReady) Color(0xFF60A5FA) else Color.Red, fontWeight = FontWeight.Bold) }
+                )
+            }
+
+            Spacer(modifier = Modifier.height(16.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(IntrinsicSize.Max),
+                horizontalArrangement = Arrangement.spacedBy(16.dp)
+            ) {
+                QuickActionButton(
+                    title = "Thermal Diagnostics",
+                    subtitle = "Find what's causing frame drops",
+                    iconContainerColor = Color(0xFFEF4444).copy(alpha = 0.1f),
+                    iconContentColor = Color(0xFFF87171),
+                    onClick = onNavigateToThermalDiagnostics,
+                    modifier = Modifier.fillMaxWidth().fillMaxHeight(),
+                    icon = { Icon(Icons.Default.LocalFireDepartment, null) }
                 )
             }
 

--- a/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.filled.ArrowBackIosNew
 import androidx.compose.material.icons.filled.DeveloperBoard
 import androidx.compose.material.icons.filled.DeviceThermostat
 import androidx.compose.material.icons.filled.DragIndicator
+import androidx.compose.material.icons.filled.LocalFireDepartment
 import androidx.compose.material.icons.filled.Memory
 import androidx.compose.material.icons.filled.NetworkCheck
 import androidx.compose.material.icons.filled.Speed
@@ -95,6 +96,7 @@ fun OverlayCustomizationScreen(
                 MetricModule("cpu_cluster", "CPU Clusters", "U: 2.8G | P: 2.2G | E: 1.6G", Icons.Default.Memory, savedModules.contains("cpu_cluster")),
                 MetricModule("ram", "RAM Usage", "4.2 GB", Icons.Default.DeveloperBoard, savedModules.contains("ram")),
                 MetricModule("temp", "Battery Temp", "38°C", Icons.Default.DeviceThermostat, savedModules.contains("temp")),
+                MetricModule("thermal", "Thermal Monitor", "CPU 63°C · MODERATE", Icons.Default.LocalFireDepartment, savedModules.contains("thermal")),
                 MetricModule("net", "Network Speed", "1.2 MB", Icons.Default.NetworkCheck, savedModules.contains("net"))
             )
         )

--- a/app/src/main/java/com/framex/app/ui/screens/PerformanceScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/PerformanceScreen.kt
@@ -111,14 +111,14 @@ class PerformanceViewModel @Inject constructor(
         // overlay toggle — via a transient override, not by mutating their setting.
         // "ping" must be included here or PingMonitor never starts polling, and
         // the PING card reads MetricsState's default (0) forever.
-        metricsEngine.setScreenOverrideModules(setOf("cpu", "ram", "ping"))
+        metricsEngine.setScreenOverrideModules(setOf("cpu", "ram", "ping"), requesterKey = "performance_screen")
     }
 
     override fun onCleared() {
         super.onCleared()
         // Release the override so CPU/RAM polling reverts to whatever the user
         // actually has toggled on for the overlay once this screen is left.
-        metricsEngine.setScreenOverrideModules(emptySet())
+        metricsEngine.setScreenOverrideModules(emptySet(), requesterKey = "performance_screen")
     }
 
     fun loadUserApps() {

--- a/app/src/main/java/com/framex/app/ui/screens/ThermalDiagnosticsScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/ThermalDiagnosticsScreen.kt
@@ -1,0 +1,341 @@
+package com.framex.app.ui.screens
+
+import android.content.Intent
+import android.widget.Toast
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBackIosNew
+import androidx.compose.material.icons.filled.FiberManualRecord
+import androidx.compose.material.icons.filled.IosShare
+import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.framex.app.metrics.MetricsEngine
+import com.framex.app.metrics.MetricsState
+import com.framex.app.metrics.SessionLogger
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+// ---------------------------------------------------------------------------
+// ViewModel
+// ---------------------------------------------------------------------------
+
+@HiltViewModel
+class ThermalDiagnosticsViewModel @Inject constructor(
+    private val metricsEngine: MetricsEngine,
+    private val sessionLogger: SessionLogger
+) : ViewModel() {
+
+    val metricsState = metricsEngine.metricsState
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), MetricsState())
+
+    val snapshotHistory = metricsEngine.snapshotHistory
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
+
+    val isRecording = sessionLogger.isRecording
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    init {
+        // "thermal" must be forced on here or ThermalMonitor never polls and every
+        // reading on this screen stays at 0 — same override pattern PerformanceScreen
+        // uses for cpu/ram/ping. This does NOT touch the user's saved overlay toggles.
+        metricsEngine.setScreenOverrideModules(setOf("thermal"))
+    }
+
+    override fun onCleared() {
+        super.onCleared()
+        metricsEngine.setScreenOverrideModules(emptySet())
+    }
+
+    fun toggleRecording() {
+        if (sessionLogger.isRecording.value) {
+            sessionLogger.stopRecording()
+        } else {
+            sessionLogger.startRecording()
+        }
+    }
+
+    fun recordedSampleCount(): Int = sessionLogger.currentRecordingCount()
+
+    fun exportAndShare(onReady: (Intent) -> Unit, onEmpty: () -> Unit) {
+        viewModelScope.launch {
+            val file = sessionLogger.exportToFile()
+            if (file == null) {
+                onEmpty()
+            } else {
+                onReady(sessionLogger.buildShareIntent(file))
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Screen
+// ---------------------------------------------------------------------------
+
+private fun thermalStatusLabel(status: Int): String = when (status) {
+    0 -> "NONE"; 1 -> "LIGHT"; 2 -> "MODERATE"; 3 -> "SEVERE"
+    4 -> "CRITICAL"; 5 -> "EMERGENCY"; 6 -> "SHUTDOWN"; else -> "UNKNOWN"
+}
+
+private fun thermalStatusColor(status: Int): Color = when {
+    status <= 1 -> Color(0xFF34D399) // green — none/light
+    status == 2 -> Color(0xFFFBBF24) // amber — moderate (this is what tripped at your 40.6°C skin reading)
+    status == 3 -> Color(0xFFF97316) // orange — severe
+    else -> Color(0xFFEF4444)        // red — critical and above
+}
+
+@Composable
+fun ThermalDiagnosticsScreen(
+    onNavigateBack: () -> Unit,
+    viewModel: ThermalDiagnosticsViewModel = hiltViewModel()
+) {
+    val metricsState by viewModel.metricsState.collectAsState()
+    val snapshotHistory by viewModel.snapshotHistory.collectAsState()
+    val isRecording by viewModel.isRecording.collectAsState()
+    val context = LocalContext.current
+    val scope = rememberCoroutineScope()
+
+    // Last 60 snapshots (~60s at 1s cadence) drive the correlation graph — same
+    // window size as the Dashboard's FPS sparkline, so the two feel consistent.
+    val recentSnapshots = remember(snapshotHistory) { snapshotHistory.takeLast(60) }
+
+    Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
+        Column(modifier = Modifier.fillMaxSize()) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                IconButton(onClick = onNavigateBack) {
+                    Icon(Icons.Default.ArrowBackIosNew, contentDescription = "Back", tint = Color.White)
+                }
+                Column {
+                    Text("Thermal Diagnostics", style = MaterialTheme.typography.titleMedium, color = Color.White)
+                    Text("Find what's causing frame drops", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
+                }
+            }
+
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = 24.dp)
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                // Current status banner — the single most useful glance value.
+                val status = metricsState.thermalStatus
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(thermalStatusColor(status).copy(alpha = 0.12f))
+                        .border(1.dp, thermalStatusColor(status).copy(alpha = 0.3f), RoundedCornerShape(16.dp))
+                        .padding(16.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(modifier = Modifier.size(10.dp).clip(CircleShape).background(thermalStatusColor(status)))
+                    Spacer(modifier = Modifier.width(12.dp))
+                    Column {
+                        Text(
+                            "Thermal Status: ${thermalStatusLabel(status)}",
+                            color = Color.White,
+                            fontWeight = FontWeight.Bold
+                        )
+                        Text(
+                            if (status >= 2) "Android is actively throttling performance right now"
+                            else "No throttling active",
+                            color = Color.Gray,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(16.dp))
+
+                // Readings grid
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    ReadingCard("CPU", String.format("%.1f°C", metricsState.thermalCpuC), Modifier.weight(1f))
+                    ReadingCard("GPU", String.format("%.1f°C", metricsState.thermalGpuC), Modifier.weight(1f))
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    ReadingCard("SKIN", String.format("%.1f°C", metricsState.thermalSkinC), Modifier.weight(1f))
+                    ReadingCard("BATTERY", String.format("%.1f°C", metricsState.batteryTempC), Modifier.weight(1f))
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+                Text("FPS vs Thermal — last 60s", style = MaterialTheme.typography.titleSmall, color = Color.White)
+                Text(
+                    "Look for the moment FPS drops and check what moved at the same second below.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray
+                )
+                Spacer(modifier = Modifier.height(12.dp))
+
+                CorrelationGraph(
+                    snapshots = recentSnapshots,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(220.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(MaterialTheme.colorScheme.surface)
+                        .border(1.dp, Color.White.copy(0.05f), RoundedCornerShape(16.dp))
+                        .padding(12.dp)
+                )
+
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    LegendDot(Color(0xFF60A5FA)); Text(" FPS   ", color = Color.Gray, style = MaterialTheme.typography.labelSmall)
+                    LegendDot(Color(0xFFEF4444)); Text(" CPU Temp   ", color = Color.Gray, style = MaterialTheme.typography.labelSmall)
+                    LegendDot(Color(0xFFFBBF24)); Text(" SKIN Temp", color = Color.Gray, style = MaterialTheme.typography.labelSmall)
+                }
+
+                Spacer(modifier = Modifier.height(32.dp))
+
+                Text("Session Recording", style = MaterialTheme.typography.titleSmall, color = Color.White)
+                Text(
+                    "Record a full gaming session, then export and share the log — every metric, every second, even ones not shown on your overlay.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray
+                )
+                Spacer(modifier = Modifier.height(16.dp))
+
+                if (isRecording) {
+                    val count = viewModel.recordedSampleCount()
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(Color(0xFFEF4444).copy(alpha = 0.1f))
+                            .padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Default.FiberManualRecord, contentDescription = null, tint = Color(0xFFEF4444), modifier = Modifier.size(12.dp))
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Recording — ${count}s captured", color = Color.White, fontWeight = FontWeight.Bold)
+                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                }
+
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    Button(
+                        onClick = { viewModel.toggleRecording() },
+                        modifier = Modifier.weight(1f).height(52.dp),
+                        shape = RoundedCornerShape(12.dp),
+                        colors = ButtonDefaults.buttonColors(
+                            containerColor = if (isRecording) Color(0xFFEF4444) else MaterialTheme.colorScheme.primary
+                        )
+                    ) {
+                        Icon(if (isRecording) Icons.Default.Stop else Icons.Default.FiberManualRecord, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text(if (isRecording) "Stop" else "Start Recording", fontWeight = FontWeight.Bold)
+                    }
+                    OutlinedButton(
+                        onClick = {
+                            viewModel.exportAndShare(
+                                onReady = { intent ->
+                                    context.startActivity(Intent.createChooser(intent, "Share session log"))
+                                },
+                                onEmpty = {
+                                    Toast.makeText(context, "Nothing recorded yet — start a session first", Toast.LENGTH_SHORT).show()
+                                }
+                            )
+                        },
+                        modifier = Modifier.weight(1f).height(52.dp),
+                        shape = RoundedCornerShape(12.dp)
+                    ) {
+                        Icon(Icons.Default.IosShare, contentDescription = null, modifier = Modifier.size(18.dp))
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Export & Share")
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(40.dp))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ReadingCard(label: String, value: String, modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .border(1.dp, Color.White.copy(0.05f), RoundedCornerShape(12.dp))
+            .padding(14.dp)
+    ) {
+        Text(label, color = Color.Gray, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
+        Spacer(modifier = Modifier.height(4.dp))
+        Text(value, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 20.sp)
+    }
+}
+
+@Composable
+private fun LegendDot(color: Color) {
+    Box(modifier = Modifier.size(8.dp).clip(CircleShape).background(color))
+}
+
+@Composable
+private fun CorrelationGraph(
+    snapshots: List<MetricsEngine.MetricsSnapshot>,
+    modifier: Modifier = Modifier
+) {
+    Canvas(modifier = modifier) {
+        if (snapshots.size < 2) return@Canvas
+
+        val maxFps = (snapshots.maxOfOrNull { it.state.fps } ?: 1).coerceAtLeast(1)
+        val maxTemp = (snapshots.maxOfOrNull { maxOf(it.state.thermalCpuC, it.state.thermalSkinC) } ?: 1f).coerceAtLeast(1f)
+
+        val stepX = size.width / (snapshots.size - 1).coerceAtLeast(1)
+
+        fun pointsFor(values: List<Float>, max: Float): List<Offset> =
+            values.mapIndexed { i, v ->
+                Offset(i * stepX, size.height - (v / max) * size.height)
+            }
+
+        val fpsPoints = pointsFor(snapshots.map { it.state.fps.toFloat() }, maxFps.toFloat())
+        val cpuPoints = pointsFor(snapshots.map { it.state.thermalCpuC }, maxTemp)
+        val skinPoints = pointsFor(snapshots.map { it.state.thermalSkinC }, maxTemp)
+
+        fun drawLine(points: List<Offset>, color: Color) {
+            for (i in 0 until points.size - 1) {
+                drawLine(
+                    color = color,
+                    start = points[i],
+                    end = points[i + 1],
+                    strokeWidth = 3f,
+                    cap = StrokeCap.Round
+                )
+            }
+        }
+
+        drawLine(cpuPoints, Color(0xFFEF4444).copy(alpha = 0.8f))
+        drawLine(skinPoints, Color(0xFFFBBF24).copy(alpha = 0.8f))
+        drawLine(fpsPoints, Color(0xFF60A5FA))
+    }
+}

--- a/app/src/main/java/com/framex/app/ui/screens/ThermalDiagnosticsScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/ThermalDiagnosticsScreen.kt
@@ -60,15 +60,16 @@ class ThermalDiagnosticsViewModel @Inject constructor(
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
     init {
-        // "thermal" must be forced on here or ThermalMonitor never polls and every
-        // reading on this screen stays at 0 — same override pattern PerformanceScreen
-        // uses for cpu/ram/ping. This does NOT touch the user's saved overlay toggles.
-        metricsEngine.setScreenOverrideModules(setOf("thermal"))
+        // Force "thermal" and "temp" on for this screen — "temp" (battery) previously
+        // wasn't forced here, so BATTERY read 0 unless the user separately had it
+        // toggled on their overlay. Uses a distinct requester key so it can't collide
+        // with SessionLogger's own override when a recording is also active.
+        metricsEngine.setScreenOverrideModules(setOf("thermal", "temp"), requesterKey = "thermal_diagnostics_screen")
     }
 
     override fun onCleared() {
         super.onCleared()
-        metricsEngine.setScreenOverrideModules(emptySet())
+        metricsEngine.setScreenOverrideModules(emptySet(), requesterKey = "thermal_diagnostics_screen")
     }
 
     fun toggleRecording() {
@@ -186,6 +187,15 @@ fun ThermalDiagnosticsScreen(
                     ReadingCard("SKIN", String.format("%.1f°C", metricsState.thermalSkinC), Modifier.weight(1f))
                     ReadingCard("BATTERY", String.format("%.1f°C", metricsState.batteryTempC), Modifier.weight(1f))
                 }
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    ReadingCard("JANKY FRAMES", "${metricsState.jankyFrames}", Modifier.weight(1f))
+                    ReadingCard(
+                        "TOP PROCESS",
+                        metricsState.topProcessName?.let { "$it (${String.format("%.0f", metricsState.topProcessCpuPercent)}%)" } ?: "—",
+                        Modifier.weight(1f)
+                    )
+                }
 
                 Spacer(modifier = Modifier.height(24.dp))
                 Text("FPS vs Thermal — last 60s", style = MaterialTheme.typography.titleSmall, color = Color.White)
@@ -291,7 +301,14 @@ private fun ReadingCard(label: String, value: String, modifier: Modifier = Modif
     ) {
         Text(label, color = Color.Gray, style = MaterialTheme.typography.labelSmall, fontWeight = FontWeight.Bold)
         Spacer(modifier = Modifier.height(4.dp))
-        Text(value, color = Color.White, fontWeight = FontWeight.Bold, fontSize = 20.sp)
+        Text(
+            value,
+            color = Color.White,
+            fontWeight = FontWeight.Bold,
+            fontSize = 20.sp,
+            maxLines = 1,
+            overflow = androidx.compose.ui.text.style.TextOverflow.Ellipsis
+        )
     }
 }
 

--- a/app/src/main/res/xml/file_paths.xml
+++ b/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths xmlns:android="http://schemas.android.com/apk/res/android">
+    <!-- Matches SessionLogger's File(context.filesDir, "session_logs") output dir. -->
+    <files-path name="session_logs" path="session_logs/" />
+</paths>


### PR DESCRIPTION
## What this adds

- **ThermalMonitor** now parses `dumpsys thermalservice` for CPU/GPU/NPU/SKIN/BATTERY temps and numeric Android thermal status (0-6), instead of just a throttling boolean.
- **MetricsEngine** keeps a rolling 1hr snapshot history of every metric on one timeline, independent of which overlay modules are toggled on - needed so recording captures metrics the user did not choose to display.
- **SessionLogger**: start/stop recording, export to CSV, share via FileProvider.
- **ThermalDiagnosticsScreen**: live thermal status banner, CPU/GPU/SKIN/battery readings, FPS-vs-thermal correlation graph (last 60s), recording controls.
- New **Thermal Monitor** overlay module, separate from the existing Battery Temp module (battery temp reads a different sensor and does not reflect SoC throttling).
- Wired into Dashboard as a new quick-action entry point.

## Why

Battery temp (existing overlay module) reads the battery thermistor only, which stays cool during gaming even while the SoC is thermally throttling. This surfaces the actual CPU/GPU/SKIN readings and Android's own throttle-status decision so frame drops can be correlated to a real cause instead of guessed at.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added **Thermal Diagnostics** screen with color-coded thermal banner, CPU/GPU/Skin/Battery readings, **janky frames**, **top process**, and FPS vs thermal correlation.
  * Added **Thermal** overlay module.
  * Added **session recording** with CSV export and share, backed by recent rolling metrics history.
* **Improvements**
  * Enhanced performance metrics with **janky frames**, detailed thermal breakdown, and snapshot history.
  * Improved module override scoping and thermal/top-process data wiring.
* **Chores**
  * Added Android **FileProvider** support and `file_paths` configuration for sharing exported logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->