### PR TITLE
Fix #16: Overlay Config modules are now actually draggable and reorderable

### DIFF
--- a/app/src/main/java/com/framex/app/metrics/MetricModule.kt
+++ b/app/src/main/java/com/framex/app/metrics/MetricModule.kt
@@ -1,0 +1,132 @@
+package com.framex.app.metrics
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeveloperBoard
+import androidx.compose.material.icons.filled.DeviceThermostat
+import androidx.compose.material.icons.filled.LocalFireDepartment
+import androidx.compose.material.icons.filled.Memory
+import androidx.compose.material.icons.filled.NetworkCheck
+import androidx.compose.material.icons.filled.Speed
+import androidx.compose.ui.graphics.vector.ImageVector
+
+/**
+ * Every metric the overlay can display. [storageKey] is the identifier persisted to
+ * SharedPreferences (both in the enabled-modules set and the module-order list) and
+ * must never change once shipped, or existing users' saved configuration breaks.
+ */
+enum class MetricModuleId(val storageKey: String) {
+    FPS("fps"),
+    CPU_FREQUENCY("cpu"),
+    CPU_CLUSTERS("cpu_cluster"),
+    RAM_USAGE("ram"),
+    BATTERY_TEMPERATURE("temp"),
+    THERMAL_MONITOR("thermal"),
+    NETWORK_SPEED("net");
+
+    companion object {
+        fun fromStorageKey(storageKey: String): MetricModuleId? =
+            entries.firstOrNull { it.storageKey == storageKey }
+    }
+}
+
+/** Static identity of a metric module: how it looks and reads before any live data arrives. */
+data class MetricModuleInfo(
+    val id: MetricModuleId,
+    val displayName: String,
+    /** Compact caps label shown in the on-screen overlay itself, where space is tight. */
+    val overlayShortLabel: String,
+    val icon: ImageVector,
+    val previewSampleValue: String
+)
+
+/**
+ * Canonical fallback order. Used verbatim for first-run users, and to place any
+ * module the app introduces in a future release that isn't yet in a returning
+ * user's persisted order (see [resolveMetricModuleOrder]).
+ */
+val DEFAULT_METRIC_MODULE_ORDER: List<MetricModuleId> = listOf(
+    MetricModuleId.FPS,
+    MetricModuleId.CPU_FREQUENCY,
+    MetricModuleId.CPU_CLUSTERS,
+    MetricModuleId.RAM_USAGE,
+    MetricModuleId.BATTERY_TEMPERATURE,
+    MetricModuleId.THERMAL_MONITOR,
+    MetricModuleId.NETWORK_SPEED
+)
+
+val METRIC_MODULE_REGISTRY: Map<MetricModuleId, MetricModuleInfo> = listOf(
+    MetricModuleInfo(MetricModuleId.FPS, "Frames Per Second", "FPS", Icons.Default.Speed, "120"),
+    MetricModuleInfo(MetricModuleId.CPU_FREQUENCY, "CPU Frequency", "CPU", Icons.Default.Memory, "2.8 GHz"),
+    MetricModuleInfo(
+        MetricModuleId.CPU_CLUSTERS,
+        "CPU Clusters",
+        "CPU Clusters",
+        Icons.Default.Memory,
+        "U: 2.8G | P: 2.2G | E: 1.6G"
+    ),
+    MetricModuleInfo(MetricModuleId.RAM_USAGE, "RAM Usage", "RAM", Icons.Default.DeveloperBoard, "4.2 GB"),
+    MetricModuleInfo(MetricModuleId.BATTERY_TEMPERATURE, "Battery Temp", "TEMP", Icons.Default.DeviceThermostat, "38°C"),
+    MetricModuleInfo(
+        MetricModuleId.THERMAL_MONITOR,
+        "Thermal Monitor",
+        "THERMAL",
+        Icons.Default.LocalFireDepartment,
+        "CPU 63°C · MODERATE"
+    ),
+    MetricModuleInfo(MetricModuleId.NETWORK_SPEED, "Network Speed", "NET", Icons.Default.NetworkCheck, "1.2 MB")
+).associateBy { it.id }
+
+/**
+ * Reconciles a persisted, user-customized order against the current set of known
+ * modules. Unknown keys (e.g. from a downgraded app version) are dropped. Any
+ * canonical module missing from [persistedOrder] (e.g. newly added in an update)
+ * is appended at its canonical position so it appears somewhere sane without
+ * disturbing the user's existing customization.
+ */
+fun resolveMetricModuleOrder(persistedOrder: List<String>): List<MetricModuleId> {
+    if (persistedOrder.isEmpty()) return DEFAULT_METRIC_MODULE_ORDER
+
+    val known = persistedOrder.mapNotNull { MetricModuleId.fromStorageKey(it) }
+    val missing = DEFAULT_METRIC_MODULE_ORDER.filterNot { it in known }
+    return known + missing
+}
+
+/** Formats the live value of [id] from [metricsState] for display in the overlay. */
+fun metricValueFor(id: MetricModuleId, metricsState: MetricsState): String = when (id) {
+    MetricModuleId.FPS -> "${metricsState.fps}"
+    MetricModuleId.CPU_FREQUENCY -> "${metricsState.cpuMhz} MHz"
+    MetricModuleId.CPU_CLUSTERS -> String.format(
+        "U:%d P:%d E:%d",
+        metricsState.cpuClusterUltraMhz,
+        metricsState.cpuClusterPerfMhz,
+        metricsState.cpuClusterEffMhz
+    )
+    MetricModuleId.RAM_USAGE -> String.format("%.1f GB", metricsState.ramUsedGb)
+    MetricModuleId.BATTERY_TEMPERATURE -> String.format("%.1f°C", metricsState.batteryTempC)
+    MetricModuleId.THERMAL_MONITOR -> String.format(
+        "%.0f°C %s",
+        metricsState.thermalCpuC,
+        thermalStatusShortLabel(metricsState.thermalStatus)
+    )
+    MetricModuleId.NETWORK_SPEED -> {
+        val totalKbps = metricsState.networkRxKbps + metricsState.networkTxKbps
+        if (totalKbps > KBPS_PER_MBPS) {
+            String.format("%.1f MB/s", totalKbps / KBPS_PER_MBPS)
+        } else {
+            String.format("%.0f KB/s", totalKbps)
+        }
+    }
+}
+
+/** Short label for the overlay's compact/minimal display — full names are used in
+ *  the Performance/detail screens where there's room to show "MODERATE" in full. */
+fun thermalStatusShortLabel(status: Int): String = when (status) {
+    0, 1 -> "OK"
+    2 -> "WARM"
+    3 -> "HOT"
+    4 -> "CRIT"
+    5, 6 -> "!!!"
+    else -> "?"
+}
+
+private const val KBPS_PER_MBPS = 1024f

--- a/app/src/main/java/com/framex/app/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/framex/app/overlay/OverlayManager.kt
@@ -32,15 +32,15 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
+import com.framex.app.metrics.METRIC_MODULE_REGISTRY
+import com.framex.app.metrics.metricValueFor
+import com.framex.app.metrics.resolveMetricModuleOrder
 import com.framex.app.ui.theme.FrameXTheme
 import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
@@ -70,6 +70,7 @@ class OverlayManager @Inject constructor(
                 FrameXTheme {
                     val mode by settingsRepository.overlayMode.collectAsState()
                     val enabledModules by settingsRepository.enabledModules.collectAsState()
+                    val moduleOrder by settingsRepository.moduleOrder.collectAsState()
                     val opacity by settingsRepository.overlayOpacity.collectAsState()
                     val textSize by settingsRepository.overlayTextSize.collectAsState()
                     val useMonospace by settingsRepository.overlayUseMonospace.collectAsState()
@@ -82,6 +83,7 @@ class OverlayManager @Inject constructor(
                     OverlayContent(
                         mode = mode,
                         enabledModules = enabledModules,
+                        moduleOrder = moduleOrder,
                         opacity = opacity,
                         textSize = textSize,
                         useMonospace = useMonospace,
@@ -268,6 +270,7 @@ class OverlayManager @Inject constructor(
 fun OverlayContent(
     mode: String,
     enabledModules: Set<String>,
+    moduleOrder: List<String>,
     opacity: Float,
     textSize: Int,
     useMonospace: Boolean,
@@ -280,21 +283,14 @@ fun OverlayContent(
     onDragEnd: () -> Unit = {},
     onModeToggle: () -> Unit = {}
 ) {
-    val availableModules = listOf(
-        Triple("fps", "FPS", "${metricsState.fps}") to Icons.Default.Speed,
-        Triple("cpu", "CPU", "${metricsState.cpuMhz} MHz") to Icons.Default.Memory,
-        Triple("cpu_cluster", "CPU Clusters", "U:${metricsState.cpuClusterUltraMhz} P:${metricsState.cpuClusterPerfMhz} E:${metricsState.cpuClusterEffMhz}") to Icons.Default.Memory,
-        Triple("ram", "RAM", String.format("%.1f GB", metricsState.ramUsedGb)) to Icons.Default.DeveloperBoard,
-        Triple("temp", "TEMP", String.format("%.1f°C", metricsState.batteryTempC)) to Icons.Default.DeviceThermostat,
-        Triple(
-            "thermal",
-            "THERMAL",
-            String.format("%.0f°C %s", metricsState.thermalCpuC, thermalStatusShortLabel(metricsState.thermalStatus))
-        ) to Icons.Default.LocalFireDepartment,
-        Triple("net", "NET", if (metricsState.networkRxKbps > 1024) String.format("%.1f MB/s", (metricsState.networkRxKbps + metricsState.networkTxKbps) / 1024f) else String.format("%.0f KB/s", metricsState.networkRxKbps + metricsState.networkTxKbps)) to Icons.Default.NetworkCheck
-    )
-    
-    val activeList = availableModules.filter { enabledModules.contains(it.first.first) }
+    // Ordered per the user's Overlay Config customization (falls back to canonical order
+    // for first-run users, or for any module introduced since they last customized it).
+    val activeList = resolveMetricModuleOrder(moduleOrder)
+        .filter { enabledModules.contains(it.storageKey) }
+        .map { id ->
+            val info = METRIC_MODULE_REGISTRY.getValue(id)
+            Triple(id.storageKey, info.overlayShortLabel, metricValueFor(id, metricsState)) to info.icon
+        }
     
     val colors = listOf(
         MaterialTheme.colorScheme.primary,
@@ -392,13 +388,6 @@ fun OverlayContent(
             }
         }
     }
-}
-
-// Short label for the overlay's compact/minimal display — full names are used in
-// the Performance/detail screens where there's room to show "MODERATE" in full.
-private fun thermalStatusShortLabel(status: Int): String = when (status) {
-    0 -> "OK"; 1 -> "OK"; 2 -> "WARM"; 3 -> "HOT"
-    4 -> "CRIT"; 5, 6 -> "!!!"; else -> "?"
 }
 
 private class OverlayLifecycleOwner : SavedStateRegistryOwner, ViewModelStoreOwner {

--- a/app/src/main/java/com/framex/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/framex/app/repository/SettingsRepository.kt
@@ -24,6 +24,21 @@ class SettingsRepository @Inject constructor(
     )
     val enabledModules: StateFlow<Set<String>> = _enabledModules.asStateFlow()
 
+    // Display order of metric modules (both enabled and disabled), as module storage keys.
+    // Stored as a single delimited string rather than a StringSet — SharedPreferences'
+    // StringSet has no guaranteed iteration order, which would silently discard any
+    // ordering the user set up via drag-and-drop in Overlay Config. Empty when the user
+    // has never customized ordering; callers fall back to the canonical default order
+    // (see MetricModule.kt's resolveMetricModuleOrder).
+    private val _moduleOrder = MutableStateFlow(loadModuleOrder())
+    val moduleOrder: StateFlow<List<String>> = _moduleOrder.asStateFlow()
+
+    private fun loadModuleOrder(): List<String> =
+        prefs.getString(KEY_MODULE_ORDER, null)
+            ?.split(MODULE_ORDER_DELIMITER)
+            ?.filter { it.isNotBlank() }
+            ?: emptyList()
+
     private val _overlayOpacity = MutableStateFlow(prefs.getFloat(KEY_OVERLAY_OPACITY, 0.75f))
     val overlayOpacity: StateFlow<Float> = _overlayOpacity.asStateFlow()
 
@@ -66,6 +81,11 @@ class SettingsRepository @Inject constructor(
     fun setEnabledModules(modules: Set<String>) {
         prefs.edit().putStringSet(KEY_ENABLED_MODULES, modules).apply()
         _enabledModules.value = modules
+    }
+
+    fun setModuleOrder(order: List<String>) {
+        prefs.edit().putString(KEY_MODULE_ORDER, order.joinToString(MODULE_ORDER_DELIMITER)).apply()
+        _moduleOrder.value = order
     }
 
     fun setOverlayOpacity(opacity: Float) {
@@ -193,6 +213,8 @@ class SettingsRepository @Inject constructor(
     companion object {
         private const val KEY_OVERLAY_MODE = "overlay_mode"
         private const val KEY_ENABLED_MODULES = "enabled_modules"
+        private const val KEY_MODULE_ORDER = "module_order"
+        private const val MODULE_ORDER_DELIMITER = ","
         private const val KEY_OVERLAY_OPACITY = "overlay_opacity"
         private const val KEY_OVERLAY_TEXT_SIZE = "overlay_text_size"
         private const val KEY_OVERLAY_USE_MONOSPACE = "overlay_use_monospace"

--- a/app/src/main/java/com/framex/app/ui/components/ReorderableList.kt
+++ b/app/src/main/java/com/framex/app/ui/components/ReorderableList.kt
@@ -1,0 +1,172 @@
+package com.framex.app.ui.components
+
+import androidx.compose.foundation.gestures.detectDragGestures
+import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/** Distance from a scrollable edge, in px, that triggers autoscroll while dragging. */
+private const val AUTO_SCROLL_EDGE_THRESHOLD_PX = 120f
+
+/** Autoscroll speed in px per triggered scroll step while the drag sits in the edge zone. */
+private const val AUTO_SCROLL_SPEED_PX = 16f
+
+/**
+ * Tracks a handle-driven drag-to-reorder gesture against a [LazyListState]'s live layout.
+ *
+ * This holds only *where the drag currently is*; it never mutates the caller's list. Each
+ * [onDrag] call may invoke [onMove] zero or more times as the dragged row's midpoint crosses
+ * a neighboring row's midpoint, and the caller is expected to apply that move to its own
+ * list state before the next recomposition.
+ */
+internal class ReorderableListState(
+    private val lazyListState: LazyListState,
+    private val coroutineScope: CoroutineScope,
+    private val onMove: (from: Int, to: Int) -> Unit
+) {
+    var draggingItemIndex by mutableStateOf<Int?>(null)
+        private set
+
+    var draggingItemOffset by mutableFloatStateOf(0f)
+        private set
+
+    private val draggingItemLayoutInfo
+        get() = lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == draggingItemIndex }
+
+    fun onDragStart(itemIndex: Int) {
+        draggingItemIndex = itemIndex
+        draggingItemOffset = 0f
+    }
+
+    fun onDrag(deltaY: Float) {
+        if (draggingItemIndex == null) return
+        draggingItemOffset += deltaY
+
+        val currentLayout = draggingItemLayoutInfo ?: return
+        val draggedTop = currentLayout.offset + draggingItemOffset
+        val draggedMiddle = draggedTop + currentLayout.size / 2f
+
+        val targetLayout = lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { candidate ->
+            candidate.index != draggingItemIndex &&
+                draggedMiddle >= candidate.offset &&
+                draggedMiddle <= candidate.offset + candidate.size
+        }
+
+        if (targetLayout != null) {
+            val fromIndex = requireNotNull(draggingItemIndex)
+            // Keep the dragged row's absolute screen position continuous across the swap by
+            // correcting for the (usually zero, but not guaranteed) size difference between rows.
+            draggingItemOffset += (currentLayout.offset - targetLayout.offset).toFloat()
+            onMove(fromIndex, targetLayout.index)
+            draggingItemIndex = targetLayout.index
+        }
+
+        autoScrollIfNearEdge(draggedTop, draggedTop + currentLayout.size)
+    }
+
+    fun onDragEnd() {
+        draggingItemIndex = null
+        draggingItemOffset = 0f
+    }
+
+    private fun autoScrollIfNearEdge(draggedTop: Float, draggedBottom: Float) {
+        val layoutInfo = lazyListState.layoutInfo
+        val viewportStart = layoutInfo.viewportStartOffset.toFloat()
+        val viewportEnd = layoutInfo.viewportEndOffset.toFloat()
+
+        val scrollDelta = when {
+            draggedTop <= viewportStart + AUTO_SCROLL_EDGE_THRESHOLD_PX && lazyListState.canScrollBackward ->
+                -AUTO_SCROLL_SPEED_PX
+            draggedBottom >= viewportEnd - AUTO_SCROLL_EDGE_THRESHOLD_PX && lazyListState.canScrollForward ->
+                AUTO_SCROLL_SPEED_PX
+            else -> 0f
+        }
+
+        if (scrollDelta != 0f) {
+            coroutineScope.launch {
+                lazyListState.scrollBy(scrollDelta)
+                draggingItemOffset += scrollDelta
+            }
+        }
+    }
+}
+
+/**
+ * A [LazyColumn] whose rows can be reordered by dragging a designated handle. [itemContent]
+ * receives the [Modifier] to attach to that handle (typically a drag-indicator icon) plus the
+ * live drag state for that row — only touches starting on the handle initiate a drag, so the
+ * rest of the row keeps its normal click/toggle behavior.
+ *
+ * @param items the current, externally-owned list. This composable never mutates it directly;
+ *   reordering is reported through [onMove] and the caller must apply it to its own state.
+ * @param key stable identity per item, required so Compose doesn't lose row state across reorders.
+ * @param onMove called with (fromIndex, toIndex) whenever the drag crosses a neighboring row's
+ *   midpoint.
+ * @param itemContent given the item, the drag-handle [Modifier], and the row's current visual
+ *   drag offset in pixels (nonzero only for the row actively being dragged — apply it via
+ *   `Modifier.graphicsLayer { translationY = dragOffsetPx }`).
+ */
+@Composable
+fun <T> ReorderableList(
+    items: List<T>,
+    key: (T) -> Any,
+    onMove: (from: Int, to: Int) -> Unit,
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(0.dp),
+    itemContent: @Composable (item: T, dragHandleModifier: Modifier, dragOffsetPx: Float) -> Unit
+) {
+    val lazyListState = rememberLazyListState()
+    val coroutineScope = rememberCoroutineScope()
+    val reorderState = remember(lazyListState, coroutineScope) {
+        ReorderableListState(
+            lazyListState = lazyListState,
+            coroutineScope = coroutineScope,
+            onMove = onMove
+        )
+    }
+
+    LazyColumn(
+        state = lazyListState,
+        modifier = modifier,
+        contentPadding = contentPadding
+    ) {
+        itemsIndexed(items, key = { _, item -> key(item) }) { index, item ->
+            // pointerInput below is keyed by the item's stable identity, not its index, so
+            // the gesture-detection coroutine is never restarted by a reorder — it keeps
+            // running across the item's lifetime. A plain captured `index` would therefore
+            // go stale the moment this row moves. rememberUpdatedState keeps onDragStart
+            // reading whatever index this row currently holds at the moment a new drag begins.
+            val latestIndex = rememberUpdatedState(index)
+            val dragOffsetPx = if (reorderState.draggingItemIndex == index) reorderState.draggingItemOffset else 0f
+            val handleModifier = Modifier.pointerInput(key(item)) {
+                detectDragGestures(
+                    onDragStart = { reorderState.onDragStart(latestIndex.value) },
+                    onDragEnd = { reorderState.onDragEnd() },
+                    onDragCancel = { reorderState.onDragEnd() },
+                    onDrag = { change, dragAmount ->
+                        change.consume()
+                        reorderState.onDrag(dragAmount.y)
+                    }
+                )
+            }
+
+            itemContent(item, handleModifier, dragOffsetPx)
+        }
+    }
+}

--- a/app/src/main/java/com/framex/app/ui/components/ReorderableList.kt
+++ b/app/src/main/java/com/framex/app/ui/components/ReorderableList.kt
@@ -1,5 +1,6 @@
 package com.framex.app.ui.components
 
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Box
@@ -8,10 +9,12 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyItemScope
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -31,12 +34,10 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlin.math.roundToInt
 
 /** Content-space distance from the viewport edge, in px, that triggers autoscroll while held. */
 private const val AUTO_SCROLL_EDGE_ZONE_PX = 150f
-
-/** Autoscroll speed in px per tick while a held row sits inside the edge zone. */
-private const val AUTO_SCROLL_SPEED_PX = 14f
 
 /** How often the autoscroll loop advances while active, in milliseconds. */
 private const val AUTO_SCROLL_TICK_MS = 16L
@@ -45,25 +46,18 @@ private const val AUTO_SCROLL_TICK_MS = 16L
 private val DRAG_HANDLE_TOUCH_PADDING = 8.dp
 
 /**
- * Drives a handle-triggered drag-to-reorder gesture for a [LazyColumn] of uniform-height rows.
- *
- * Deliberately avoids reading [LazyListState.layoutInfo]'s per-item info mid-gesture: that data
- * reflects the *previous* layout pass and lags behind rapid pointer events, which is what
- * previously caused the drag to compute swap targets against stale positions — producing
- * overlapping rows, growing gaps, and the drag appearing to "let go" mid-motion. Instead, because
- * every row has the same [itemHeightPx], a row's position is pure arithmetic
- * (`index * itemHeightPx`), so the entire gesture is tracked as an accumulated content-space
- * offset — correct regardless of what LazyColumn's virtualization or recomposition timing is
- * doing, and correct even when the target row isn't currently rendered (e.g. dragging the top
- * row down past several screens' worth of content).
+ * Tracks the drag gesture parameters and calculates slot indexes and offsets Authoritatively,
+ * factoring in both item height and item spacing to prevent drift and visual jumping.
  */
 private class UniformReorderState(
     private val lazyListState: LazyListState,
     private val coroutineScope: CoroutineScope,
     private val itemCount: () -> Int,
     private val itemHeightPx: Float,
+    private val itemSpacingPx: Float,
     private val topContentPaddingPx: Float,
-    private val onMove: (from: Int, to: Int) -> Unit
+    private val minReorderIndex: Int,
+    private val onMoveState: State<(from: Int, to: Int) -> Unit>
 ) {
     /** Index of the row currently being dragged, or null when no drag is in progress. */
     var draggingIndex by mutableStateOf<Int?>(null)
@@ -80,20 +74,35 @@ private class UniformReorderState(
     /** Authoritative content-space Y (unaffected by scroll) of the dragged row's center. */
     private var draggedCenterContentSpace = 0f
 
-    private var autoScrollDirection = 0
+    private var autoScrollSpeed = 0f
     private var autoScrollJob: Job? = null
 
+    private val slotHeightPx: Float
+        get() = itemHeightPx + itemSpacingPx
+
     fun onDragStart(index: Int) {
+        if (index < minReorderIndex) return
         draggingIndex = index
-        draggedCenterContentSpace = (index + 0.5f) * itemHeightPx
+        draggedCenterContentSpace = topContentPaddingPx + index * slotHeightPx + itemHeightPx / 2
         dragOffsetPx = 0f
+        autoScrollSpeed = 0f
     }
 
     fun onDrag(deltaY: Float) {
         if (draggingIndex == null) return
         draggedCenterContentSpace += deltaY
+        
+        // Clamp draggedCenterContentSpace within valid bounds of the list to prevent card from flying off-screen
+        val count = itemCount()
+        if (count > 0) {
+            val minIndex = minReorderIndex.coerceIn(0, count - 1)
+            val minCenter = topContentPaddingPx + minIndex * slotHeightPx + itemHeightPx / 2
+            val maxCenter = topContentPaddingPx + (count - 1) * slotHeightPx + itemHeightPx / 2
+            draggedCenterContentSpace = draggedCenterContentSpace.coerceIn(minCenter, maxCenter)
+        }
+
         recomputeSlotAndOffset()
-        recomputeAutoScrollDirection()
+        recomputeAutoScrollSpeed()
         ensureAutoScrollLoopRunning()
     }
 
@@ -104,54 +113,75 @@ private class UniformReorderState(
         draggingIndex = null
         dragOffsetPx = 0f
         draggedCenterContentSpace = 0f
-        autoScrollDirection = 0
+        autoScrollSpeed = 0f
     }
 
     private fun recomputeSlotAndOffset() {
         val current = draggingIndex ?: return
-        val targetIndex = (draggedCenterContentSpace / itemHeightPx)
-            .toInt()
-            .coerceIn(0, (itemCount() - 1).coerceAtLeast(0))
+        val count = itemCount()
+        if (count == 0) return
+
+        val minIndex = minReorderIndex.coerceIn(0, count - 1)
+        val targetIndex = ((draggedCenterContentSpace - topContentPaddingPx - itemHeightPx / 2) / slotHeightPx)
+            .roundToInt()
+            .coerceIn(minIndex, count - 1)
 
         if (targetIndex != current) {
-            onMove(current, targetIndex)
+            onMoveState.value(current, targetIndex)
             draggingIndex = targetIndex
         }
 
         val settledIndex = draggingIndex ?: return
-        dragOffsetPx = draggedCenterContentSpace - (settledIndex + 0.5f) * itemHeightPx
+        val naturalCenter = topContentPaddingPx + settledIndex * slotHeightPx + itemHeightPx / 2
+        dragOffsetPx = draggedCenterContentSpace - naturalCenter
     }
 
-    private fun currentScrollOffsetPx(): Float =
-        lazyListState.firstVisibleItemIndex * itemHeightPx + lazyListState.firstVisibleItemScrollOffset
+    private fun currentScrollOffsetPx(): Float {
+        val firstIndex = lazyListState.firstVisibleItemIndex
+        val firstOffset = lazyListState.firstVisibleItemScrollOffset
+        return if (firstIndex == 0) {
+            firstOffset.toFloat()
+        } else {
+            topContentPaddingPx + firstIndex * slotHeightPx + firstOffset
+        }
+    }
 
-    private fun recomputeAutoScrollDirection() {
-        val viewportY = draggedCenterContentSpace - currentScrollOffsetPx() + topContentPaddingPx
+    private fun recomputeAutoScrollSpeed() {
+        val viewportY = draggedCenterContentSpace - currentScrollOffsetPx()
         val viewportHeight = lazyListState.layoutInfo.viewportSize.height.toFloat()
 
-        autoScrollDirection = when {
-            viewportY < AUTO_SCROLL_EDGE_ZONE_PX && lazyListState.canScrollBackward -> -1
-            viewportY > viewportHeight - AUTO_SCROLL_EDGE_ZONE_PX && lazyListState.canScrollForward -> 1
-            else -> 0
+        autoScrollSpeed = when {
+            viewportY < AUTO_SCROLL_EDGE_ZONE_PX && lazyListState.canScrollBackward -> {
+                val ratio = (AUTO_SCROLL_EDGE_ZONE_PX - viewportY) / AUTO_SCROLL_EDGE_ZONE_PX
+                val speed = 3f + (22f * ratio.coerceIn(0f, 1f))
+                -speed
+            }
+            viewportY > viewportHeight - AUTO_SCROLL_EDGE_ZONE_PX && lazyListState.canScrollForward -> {
+                val distFromEdge = viewportY - (viewportHeight - AUTO_SCROLL_EDGE_ZONE_PX)
+                val ratio = distFromEdge / AUTO_SCROLL_EDGE_ZONE_PX
+                val speed = 3f + (22f * ratio.coerceIn(0f, 1f))
+                speed
+            }
+            else -> 0f
         }
     }
 
     /**
-     * Autoscroll must keep running while the finger is held stationary near an edge — pointer
-     * events only fire on movement, so this uses its own repeating loop rather than piggybacking
-     * on [onDrag]. Started lazily on first need and left running (cheaply idling) for the rest of
-     * the drag; [onDragEnd] is the only thing that cancels it.
+     * Autoscroll runs dynamically based on proportional speed. Swapping continues as list scrolls.
      */
     private fun ensureAutoScrollLoopRunning() {
         if (autoScrollJob?.isActive == true) return
         autoScrollJob = coroutineScope.launch {
             while (isActive && draggingIndex != null) {
-                if (autoScrollDirection != 0) {
-                    val delta = AUTO_SCROLL_SPEED_PX * autoScrollDirection
-                    lazyListState.scrollBy(delta)
-                    draggedCenterContentSpace += delta
-                    recomputeSlotAndOffset()
-                    recomputeAutoScrollDirection()
+                if (autoScrollSpeed != 0f) {
+                    val consumed = lazyListState.scrollBy(autoScrollSpeed)
+                    if (consumed != 0f) {
+                        draggedCenterContentSpace += consumed
+                        recomputeSlotAndOffset()
+                        recomputeAutoScrollSpeed()
+                    } else {
+                        autoScrollSpeed = 0f
+                    }
                 }
                 delay(AUTO_SCROLL_TICK_MS)
             }
@@ -161,21 +191,9 @@ private class UniformReorderState(
 
 /**
  * A [LazyColumn] of fixed-height rows that can be reordered by dragging a designated handle.
- * [itemContent] receives the drag-handle [Modifier] plus whether that specific row is the one
- * currently being dragged — apply "held" styling (border/elevation/etc.) based on that flag.
- * This component owns all positioning itself (tracking the dragged row under the finger and
- * elevating it above its neighbors), so [itemContent] never has to think about offsets.
- *
- * @param items the current, externally-owned list. Never mutated directly here — reordering is
- *   reported through [onMove], and the caller must apply it before the next recomposition.
- * @param key stable identity per item, so Compose preserves row state (including this
- *   component's own gesture-detection coroutine) across reorders instead of disposing it.
- * @param itemHeight the exact height every row renders at. This is a hard requirement, not a
- *   hint — content taller than this is clipped, because the drag math assumes every row occupies
- *   precisely this many pixels; see [UniformReorderState].
- * @param itemSpacing vertical gap below each row.
- * @param onMove called with (fromIndex, toIndex) whenever the drag crosses into a new slot.
+ * Includes placement animations for non-dragged rows and is fully spacing-aware.
  */
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun <T> ReorderableList(
     items: List<T>,
@@ -185,22 +203,28 @@ fun <T> ReorderableList(
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp),
     itemSpacing: Dp = 0.dp,
-    itemContent: @Composable (item: T, dragHandleModifier: Modifier, isDragging: Boolean) -> Unit
+    minReorderIndex: Int = 0,
+    itemContent: @Composable LazyItemScope.(item: T, dragHandleModifier: Modifier?, isDragging: Boolean) -> Unit
 ) {
     val density = LocalDensity.current
     val itemHeightPx = with(density) { itemHeight.toPx() }
+    val itemSpacingPx = with(density) { itemSpacing.toPx() }
     val topContentPaddingPx = with(density) { contentPadding.calculateTopPadding().toPx() }
 
     val lazyListState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
-    val reorderState = remember(lazyListState, coroutineScope, itemHeightPx, topContentPaddingPx) {
+    val onMoveState = rememberUpdatedState(onMove)
+
+    val reorderState = remember(lazyListState, coroutineScope, itemHeightPx, itemSpacingPx, topContentPaddingPx, minReorderIndex) {
         UniformReorderState(
             lazyListState = lazyListState,
             coroutineScope = coroutineScope,
             itemCount = { items.size },
             itemHeightPx = itemHeightPx,
+            itemSpacingPx = itemSpacingPx,
             topContentPaddingPx = topContentPaddingPx,
-            onMove = onMove
+            minReorderIndex = minReorderIndex,
+            onMoveState = onMoveState
         )
     }
 
@@ -210,29 +234,34 @@ fun <T> ReorderableList(
         contentPadding = contentPadding
     ) {
         itemsIndexed(items, key = { _, item -> key(item) }) { index, item ->
-            // pointerInput is keyed by the item's stable identity (not its index) so the
-            // gesture-detection coroutine survives reorders instead of restarting — which means
-            // a plain captured `index` would go stale the moment this row moves. rememberUpdatedState
-            // keeps onDragStart reading whatever index this row currently holds when a new drag begins.
             val latestIndex = rememberUpdatedState(index)
             val isDragging = reorderState.draggingIndex == index
             val offsetPx = if (isDragging) reorderState.dragOffsetPx else 0f
 
-            val handleModifier = Modifier
-                .padding(DRAG_HANDLE_TOUCH_PADDING)
-                .pointerInput(key(item)) {
-                    detectDragGestures(
-                        onDragStart = { reorderState.onDragStart(latestIndex.value) },
-                        onDragEnd = { reorderState.onDragEnd() },
-                        onDragCancel = { reorderState.onDragEnd() },
-                        onDrag = { change, dragAmount ->
-                            change.consume()
-                            reorderState.onDrag(dragAmount.y)
-                        }
-                    )
-                }
+            val handleModifier = if (index >= minReorderIndex) {
+                Modifier
+                    .padding(DRAG_HANDLE_TOUCH_PADDING)
+                    .pointerInput(key(item)) {
+                        detectDragGestures(
+                            onDragStart = { reorderState.onDragStart(latestIndex.value) },
+                            onDragEnd = { reorderState.onDragEnd() },
+                            onDragCancel = { reorderState.onDragEnd() },
+                            onDrag = { change, dragAmount ->
+                                change.consume()
+                                reorderState.onDrag(dragAmount.y)
+                            }
+                        )
+                    }
+            } else {
+                null
+            }
 
-            Box(modifier = Modifier.padding(bottom = itemSpacing)) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(bottom = itemSpacing)
+                    .then(if (isDragging) Modifier else Modifier.animateItemPlacement())
+            ) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth()

--- a/app/src/main/java/com/framex/app/ui/components/ReorderableList.kt
+++ b/app/src/main/java/com/framex/app/ui/components/ReorderableList.kt
@@ -2,7 +2,11 @@ package com.framex.app.ui.components
 
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.gestures.scrollBy
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.itemsIndexed
@@ -16,127 +20,186 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.zIndex
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 
-/** Distance from a scrollable edge, in px, that triggers autoscroll while dragging. */
-private const val AUTO_SCROLL_EDGE_THRESHOLD_PX = 120f
+/** Content-space distance from the viewport edge, in px, that triggers autoscroll while held. */
+private const val AUTO_SCROLL_EDGE_ZONE_PX = 150f
 
-/** Autoscroll speed in px per triggered scroll step while the drag sits in the edge zone. */
-private const val AUTO_SCROLL_SPEED_PX = 16f
+/** Autoscroll speed in px per tick while a held row sits inside the edge zone. */
+private const val AUTO_SCROLL_SPEED_PX = 14f
+
+/** How often the autoscroll loop advances while active, in milliseconds. */
+private const val AUTO_SCROLL_TICK_MS = 16L
+
+/** Extra invisible padding added around the drag handle to make it easier to grab reliably. */
+private val DRAG_HANDLE_TOUCH_PADDING = 8.dp
 
 /**
- * Tracks a handle-driven drag-to-reorder gesture against a [LazyListState]'s live layout.
+ * Drives a handle-triggered drag-to-reorder gesture for a [LazyColumn] of uniform-height rows.
  *
- * This holds only *where the drag currently is*; it never mutates the caller's list. Each
- * [onDrag] call may invoke [onMove] zero or more times as the dragged row's midpoint crosses
- * a neighboring row's midpoint, and the caller is expected to apply that move to its own
- * list state before the next recomposition.
+ * Deliberately avoids reading [LazyListState.layoutInfo]'s per-item info mid-gesture: that data
+ * reflects the *previous* layout pass and lags behind rapid pointer events, which is what
+ * previously caused the drag to compute swap targets against stale positions — producing
+ * overlapping rows, growing gaps, and the drag appearing to "let go" mid-motion. Instead, because
+ * every row has the same [itemHeightPx], a row's position is pure arithmetic
+ * (`index * itemHeightPx`), so the entire gesture is tracked as an accumulated content-space
+ * offset — correct regardless of what LazyColumn's virtualization or recomposition timing is
+ * doing, and correct even when the target row isn't currently rendered (e.g. dragging the top
+ * row down past several screens' worth of content).
  */
-internal class ReorderableListState(
+private class UniformReorderState(
     private val lazyListState: LazyListState,
     private val coroutineScope: CoroutineScope,
+    private val itemCount: () -> Int,
+    private val itemHeightPx: Float,
+    private val topContentPaddingPx: Float,
     private val onMove: (from: Int, to: Int) -> Unit
 ) {
-    var draggingItemIndex by mutableStateOf<Int?>(null)
+    /** Index of the row currently being dragged, or null when no drag is in progress. */
+    var draggingIndex by mutableStateOf<Int?>(null)
         private set
 
-    var draggingItemOffset by mutableFloatStateOf(0f)
+    /**
+     * Visual pixel offset to apply, via `graphicsLayer { translationY = ... }`, to whichever row
+     * currently sits at [draggingIndex] — the gap between where the gesture wants that row's
+     * center to be and where it's naturally laid out at its current slot.
+     */
+    var dragOffsetPx by mutableFloatStateOf(0f)
         private set
 
-    private val draggingItemLayoutInfo
-        get() = lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { it.index == draggingItemIndex }
+    /** Authoritative content-space Y (unaffected by scroll) of the dragged row's center. */
+    private var draggedCenterContentSpace = 0f
 
-    fun onDragStart(itemIndex: Int) {
-        draggingItemIndex = itemIndex
-        draggingItemOffset = 0f
+    private var autoScrollDirection = 0
+    private var autoScrollJob: Job? = null
+
+    fun onDragStart(index: Int) {
+        draggingIndex = index
+        draggedCenterContentSpace = (index + 0.5f) * itemHeightPx
+        dragOffsetPx = 0f
     }
 
     fun onDrag(deltaY: Float) {
-        if (draggingItemIndex == null) return
-        draggingItemOffset += deltaY
-
-        val currentLayout = draggingItemLayoutInfo ?: return
-        val draggedTop = currentLayout.offset + draggingItemOffset
-        val draggedMiddle = draggedTop + currentLayout.size / 2f
-
-        val targetLayout = lazyListState.layoutInfo.visibleItemsInfo.firstOrNull { candidate ->
-            candidate.index != draggingItemIndex &&
-                draggedMiddle >= candidate.offset &&
-                draggedMiddle <= candidate.offset + candidate.size
-        }
-
-        if (targetLayout != null) {
-            val fromIndex = requireNotNull(draggingItemIndex)
-            // Keep the dragged row's absolute screen position continuous across the swap by
-            // correcting for the (usually zero, but not guaranteed) size difference between rows.
-            draggingItemOffset += (currentLayout.offset - targetLayout.offset).toFloat()
-            onMove(fromIndex, targetLayout.index)
-            draggingItemIndex = targetLayout.index
-        }
-
-        autoScrollIfNearEdge(draggedTop, draggedTop + currentLayout.size)
+        if (draggingIndex == null) return
+        draggedCenterContentSpace += deltaY
+        recomputeSlotAndOffset()
+        recomputeAutoScrollDirection()
+        ensureAutoScrollLoopRunning()
     }
 
+    /** Ends the drag. The only place [draggingIndex] is ever cleared — no other code path resets it. */
     fun onDragEnd() {
-        draggingItemIndex = null
-        draggingItemOffset = 0f
+        autoScrollJob?.cancel()
+        autoScrollJob = null
+        draggingIndex = null
+        dragOffsetPx = 0f
+        draggedCenterContentSpace = 0f
+        autoScrollDirection = 0
     }
 
-    private fun autoScrollIfNearEdge(draggedTop: Float, draggedBottom: Float) {
-        val layoutInfo = lazyListState.layoutInfo
-        val viewportStart = layoutInfo.viewportStartOffset.toFloat()
-        val viewportEnd = layoutInfo.viewportEndOffset.toFloat()
+    private fun recomputeSlotAndOffset() {
+        val current = draggingIndex ?: return
+        val targetIndex = (draggedCenterContentSpace / itemHeightPx)
+            .toInt()
+            .coerceIn(0, (itemCount() - 1).coerceAtLeast(0))
 
-        val scrollDelta = when {
-            draggedTop <= viewportStart + AUTO_SCROLL_EDGE_THRESHOLD_PX && lazyListState.canScrollBackward ->
-                -AUTO_SCROLL_SPEED_PX
-            draggedBottom >= viewportEnd - AUTO_SCROLL_EDGE_THRESHOLD_PX && lazyListState.canScrollForward ->
-                AUTO_SCROLL_SPEED_PX
-            else -> 0f
+        if (targetIndex != current) {
+            onMove(current, targetIndex)
+            draggingIndex = targetIndex
         }
 
-        if (scrollDelta != 0f) {
-            coroutineScope.launch {
-                lazyListState.scrollBy(scrollDelta)
-                draggingItemOffset += scrollDelta
+        val settledIndex = draggingIndex ?: return
+        dragOffsetPx = draggedCenterContentSpace - (settledIndex + 0.5f) * itemHeightPx
+    }
+
+    private fun currentScrollOffsetPx(): Float =
+        lazyListState.firstVisibleItemIndex * itemHeightPx + lazyListState.firstVisibleItemScrollOffset
+
+    private fun recomputeAutoScrollDirection() {
+        val viewportY = draggedCenterContentSpace - currentScrollOffsetPx() + topContentPaddingPx
+        val viewportHeight = lazyListState.layoutInfo.viewportSize.height.toFloat()
+
+        autoScrollDirection = when {
+            viewportY < AUTO_SCROLL_EDGE_ZONE_PX && lazyListState.canScrollBackward -> -1
+            viewportY > viewportHeight - AUTO_SCROLL_EDGE_ZONE_PX && lazyListState.canScrollForward -> 1
+            else -> 0
+        }
+    }
+
+    /**
+     * Autoscroll must keep running while the finger is held stationary near an edge — pointer
+     * events only fire on movement, so this uses its own repeating loop rather than piggybacking
+     * on [onDrag]. Started lazily on first need and left running (cheaply idling) for the rest of
+     * the drag; [onDragEnd] is the only thing that cancels it.
+     */
+    private fun ensureAutoScrollLoopRunning() {
+        if (autoScrollJob?.isActive == true) return
+        autoScrollJob = coroutineScope.launch {
+            while (isActive && draggingIndex != null) {
+                if (autoScrollDirection != 0) {
+                    val delta = AUTO_SCROLL_SPEED_PX * autoScrollDirection
+                    lazyListState.scrollBy(delta)
+                    draggedCenterContentSpace += delta
+                    recomputeSlotAndOffset()
+                    recomputeAutoScrollDirection()
+                }
+                delay(AUTO_SCROLL_TICK_MS)
             }
         }
     }
 }
 
 /**
- * A [LazyColumn] whose rows can be reordered by dragging a designated handle. [itemContent]
- * receives the [Modifier] to attach to that handle (typically a drag-indicator icon) plus the
- * live drag state for that row — only touches starting on the handle initiate a drag, so the
- * rest of the row keeps its normal click/toggle behavior.
+ * A [LazyColumn] of fixed-height rows that can be reordered by dragging a designated handle.
+ * [itemContent] receives the drag-handle [Modifier] plus whether that specific row is the one
+ * currently being dragged — apply "held" styling (border/elevation/etc.) based on that flag.
+ * This component owns all positioning itself (tracking the dragged row under the finger and
+ * elevating it above its neighbors), so [itemContent] never has to think about offsets.
  *
- * @param items the current, externally-owned list. This composable never mutates it directly;
- *   reordering is reported through [onMove] and the caller must apply it to its own state.
- * @param key stable identity per item, required so Compose doesn't lose row state across reorders.
- * @param onMove called with (fromIndex, toIndex) whenever the drag crosses a neighboring row's
- *   midpoint.
- * @param itemContent given the item, the drag-handle [Modifier], and the row's current visual
- *   drag offset in pixels (nonzero only for the row actively being dragged — apply it via
- *   `Modifier.graphicsLayer { translationY = dragOffsetPx }`).
+ * @param items the current, externally-owned list. Never mutated directly here — reordering is
+ *   reported through [onMove], and the caller must apply it before the next recomposition.
+ * @param key stable identity per item, so Compose preserves row state (including this
+ *   component's own gesture-detection coroutine) across reorders instead of disposing it.
+ * @param itemHeight the exact height every row renders at. This is a hard requirement, not a
+ *   hint — content taller than this is clipped, because the drag math assumes every row occupies
+ *   precisely this many pixels; see [UniformReorderState].
+ * @param itemSpacing vertical gap below each row.
+ * @param onMove called with (fromIndex, toIndex) whenever the drag crosses into a new slot.
  */
 @Composable
 fun <T> ReorderableList(
     items: List<T>,
     key: (T) -> Any,
+    itemHeight: Dp,
     onMove: (from: Int, to: Int) -> Unit,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(0.dp),
-    itemContent: @Composable (item: T, dragHandleModifier: Modifier, dragOffsetPx: Float) -> Unit
+    itemSpacing: Dp = 0.dp,
+    itemContent: @Composable (item: T, dragHandleModifier: Modifier, isDragging: Boolean) -> Unit
 ) {
+    val density = LocalDensity.current
+    val itemHeightPx = with(density) { itemHeight.toPx() }
+    val topContentPaddingPx = with(density) { contentPadding.calculateTopPadding().toPx() }
+
     val lazyListState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
-    val reorderState = remember(lazyListState, coroutineScope) {
-        ReorderableListState(
+    val reorderState = remember(lazyListState, coroutineScope, itemHeightPx, topContentPaddingPx) {
+        UniformReorderState(
             lazyListState = lazyListState,
             coroutineScope = coroutineScope,
+            itemCount = { items.size },
+            itemHeightPx = itemHeightPx,
+            topContentPaddingPx = topContentPaddingPx,
             onMove = onMove
         )
     }
@@ -147,26 +210,39 @@ fun <T> ReorderableList(
         contentPadding = contentPadding
     ) {
         itemsIndexed(items, key = { _, item -> key(item) }) { index, item ->
-            // pointerInput below is keyed by the item's stable identity, not its index, so
-            // the gesture-detection coroutine is never restarted by a reorder — it keeps
-            // running across the item's lifetime. A plain captured `index` would therefore
-            // go stale the moment this row moves. rememberUpdatedState keeps onDragStart
-            // reading whatever index this row currently holds at the moment a new drag begins.
+            // pointerInput is keyed by the item's stable identity (not its index) so the
+            // gesture-detection coroutine survives reorders instead of restarting — which means
+            // a plain captured `index` would go stale the moment this row moves. rememberUpdatedState
+            // keeps onDragStart reading whatever index this row currently holds when a new drag begins.
             val latestIndex = rememberUpdatedState(index)
-            val dragOffsetPx = if (reorderState.draggingItemIndex == index) reorderState.draggingItemOffset else 0f
-            val handleModifier = Modifier.pointerInput(key(item)) {
-                detectDragGestures(
-                    onDragStart = { reorderState.onDragStart(latestIndex.value) },
-                    onDragEnd = { reorderState.onDragEnd() },
-                    onDragCancel = { reorderState.onDragEnd() },
-                    onDrag = { change, dragAmount ->
-                        change.consume()
-                        reorderState.onDrag(dragAmount.y)
-                    }
-                )
-            }
+            val isDragging = reorderState.draggingIndex == index
+            val offsetPx = if (isDragging) reorderState.dragOffsetPx else 0f
 
-            itemContent(item, handleModifier, dragOffsetPx)
+            val handleModifier = Modifier
+                .padding(DRAG_HANDLE_TOUCH_PADDING)
+                .pointerInput(key(item)) {
+                    detectDragGestures(
+                        onDragStart = { reorderState.onDragStart(latestIndex.value) },
+                        onDragEnd = { reorderState.onDragEnd() },
+                        onDragCancel = { reorderState.onDragEnd() },
+                        onDrag = { change, dragAmount ->
+                            change.consume()
+                            reorderState.onDrag(dragAmount.y)
+                        }
+                    )
+                }
+
+            Box(modifier = Modifier.padding(bottom = itemSpacing)) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(itemHeight)
+                        .graphicsLayer { translationY = offsetPx }
+                        .zIndex(if (isDragging) 1f else 0f)
+                ) {
+                    itemContent(item, handleModifier, isDragging)
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/framex/app/ui/screens/AppearanceScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/AppearanceScreen.kt
@@ -11,11 +11,6 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBackIosNew
 import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.DeveloperBoard
-import androidx.compose.material.icons.filled.DeviceThermostat
-import androidx.compose.material.icons.filled.Memory
-import androidx.compose.material.icons.filled.NetworkCheck
-import androidx.compose.material.icons.filled.Speed
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -40,6 +35,7 @@ class AppearanceViewModel @Inject constructor(
 ) : ViewModel() {
     val overlayMode = settingsRepository.overlayMode
     val enabledModules = settingsRepository.enabledModules
+    val moduleOrder = settingsRepository.moduleOrder
     val overlayOpacity = settingsRepository.overlayOpacity
     val overlayTextSize = settingsRepository.overlayTextSize
     val overlayUseMonospace = settingsRepository.overlayUseMonospace
@@ -76,6 +72,7 @@ fun AppearanceScreen(
     val savedTextColorIndex by viewModel.overlayTextColorIndex.collectAsState()
     val mode by viewModel.overlayMode.collectAsState()
     val enabledModules by viewModel.enabledModules.collectAsState()
+    val moduleOrder by viewModel.moduleOrder.collectAsState()
     
     val context = LocalContext.current
 
@@ -139,16 +136,14 @@ fun AppearanceScreen(
                         .clip(RoundedCornerShape(16.dp))
                         .background(Color.DarkGray)
                 ) {
-                    // Dynamic Overlay inside
-                    val availableModules = listOf(
-                        Triple("fps", "FPS", "120") to Icons.Default.Speed,
-                        Triple("cpu", "CPU", "34%") to Icons.Default.Memory,
-                        Triple("ram", "RAM", "4.2 GB") to Icons.Default.DeveloperBoard,
-                        Triple("temp", "TEMP", "38°C") to Icons.Default.DeviceThermostat,
-                        Triple("net", "NET", "1.2 MB") to Icons.Default.NetworkCheck
-                    )
-                    
-                    val activeList = availableModules.filter { enabledModules.contains(it.first.first) }
+                    // Dynamic Overlay inside — ordered per the user's Overlay Config
+                    // customization so this preview always matches the real overlay.
+                    val activeList = com.framex.app.metrics.resolveMetricModuleOrder(moduleOrder)
+                        .filter { enabledModules.contains(it.storageKey) }
+                        .map { id ->
+                            val info = com.framex.app.metrics.METRIC_MODULE_REGISTRY.getValue(id)
+                            Triple(id.storageKey, info.overlayShortLabel, info.previewSampleValue) to info.icon
+                        }
                     val accentColor = colors[selectedColorIndex]
                     val fontFamily = if (useMonospace) androidx.compose.ui.text.font.FontFamily.Monospace else MaterialTheme.typography.bodyMedium.fontFamily
                     val textScale = when(selectedTextSize) { 0 -> 0.8f; 2 -> 1.2f; else -> 1.0f }

--- a/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationComponents.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationComponents.kt
@@ -1,0 +1,250 @@
+package com.framex.app.ui.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DragIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.framex.app.metrics.METRIC_MODULE_REGISTRY
+
+/**
+ * Presentational sub-components for [OverlayCustomizationScreen]: the mode toggle, the live
+ * overlay preview card, and a single draggable module row. Kept separate from the screen's
+ * orchestration logic (state, persistence, view model) so each file stays focused.
+ */
+
+@Composable
+internal fun ModeSelector(
+    modes: List<String>,
+    selectedMode: String,
+    accentColor: Color,
+    onModeSelected: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(4.dp)
+    ) {
+        modes.forEach { mode ->
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(CircleShape)
+                    .background(if (selectedMode == mode) accentColor else Color.Transparent)
+                    .clickable { onModeSelected(mode) }
+                    .padding(vertical = 12.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = mode,
+                    color = if (selectedMode == mode) Color.White else Color.Gray,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+internal fun OverlayPreviewCard(
+    modules: List<ModuleRowState>,
+    selectedMode: String,
+    opacity: Float,
+    accentColor: Color,
+    fontFamily: FontFamily?,
+    textScale: Float,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(180.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .border(1.dp, Color.White.copy(0.05f), RoundedCornerShape(16.dp))
+    ) {
+        Column(modifier = Modifier.padding(16.dp).fillMaxSize(), verticalArrangement = Arrangement.SpaceBetween) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(MaterialTheme.colorScheme.primary.copy(0.2f))
+                        .border(1.dp, MaterialTheme.colorScheme.primary.copy(0.3f), RoundedCornerShape(6.dp))
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(modifier = Modifier.size(6.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary))
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text("Preview", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+                }
+                Text("layout_v2.json", color = Color.Gray, style = MaterialTheme.typography.labelSmall)
+            }
+
+            // Preview order always mirrors the live `modules` list state above, so what's
+            // shown here matches exactly what the overlay will render once applied.
+            val enabledModules = modules.filter { it.enabled }
+
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color.Black.copy(opacity))
+                        .border(1.dp, accentColor, RoundedCornerShape(8.dp))
+                        .padding(if (selectedMode == "Minimal") (4 * textScale).dp else (8 * textScale).dp)
+                ) {
+                    if (selectedMode == "Expanded") {
+                        Column(verticalArrangement = Arrangement.spacedBy((8 * textScale).dp)) {
+                            enabledModules.forEach { module ->
+                                val info = METRIC_MODULE_REGISTRY.getValue(module.id)
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Icon(info.icon, contentDescription = null, tint = accentColor, modifier = Modifier.size((16 * textScale).dp))
+                                    Spacer(modifier = Modifier.width((8 * textScale).dp))
+                                    Text(info.displayName, color = Color.Gray, fontSize = (10 * textScale).sp, fontFamily = fontFamily, modifier = Modifier.weight(1f))
+                                    Text(
+                                        info.previewSampleValue,
+                                        color = Color.White,
+                                        fontFamily = fontFamily,
+                                        style = MaterialTheme.typography.labelSmall.copy(fontSize = (12 * textScale).sp, fontWeight = FontWeight.Bold)
+                                    )
+                                }
+                            }
+                        }
+                    } else {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy((12 * textScale).dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(horizontal = (4 * textScale).dp)
+                        ) {
+                            enabledModules.forEachIndexed { index, module ->
+                                val info = METRIC_MODULE_REGISTRY.getValue(module.id)
+                                if (selectedMode == "Minimal") {
+                                    Text(
+                                        info.previewSampleValue,
+                                        color = Color.White,
+                                        fontFamily = fontFamily,
+                                        style = MaterialTheme.typography.labelSmall.copy(fontSize = (14 * textScale).sp, fontWeight = FontWeight.Bold)
+                                    )
+                                } else {
+                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                        Text(module.id.storageKey.uppercase(), color = Color.Gray, fontFamily = fontFamily, fontSize = (10 * textScale).sp, fontWeight = FontWeight.Bold)
+                                        Text(
+                                            info.previewSampleValue,
+                                            color = if (index == 0) accentColor else Color.White,
+                                            fontFamily = fontFamily,
+                                            style = MaterialTheme.typography.labelSmall.copy(fontSize = (16 * textScale).sp, fontWeight = FontWeight.Bold)
+                                        )
+                                    }
+                                }
+                                if (index < enabledModules.size - 1) {
+                                    Box(
+                                        modifier = Modifier
+                                            .width(1.dp)
+                                            .height(if (selectedMode == "Minimal") (12 * textScale).dp else (24 * textScale).dp)
+                                            .background(Color.DarkGray)
+                                    )
+                                }
+                            }
+                            if (enabledModules.isEmpty()) {
+                                Text("No modules selected", color = Color.Gray, fontFamily = fontFamily, fontSize = (12 * textScale).sp)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+internal fun ModuleRow(
+    module: ModuleRowState,
+    accentColor: Color,
+    isDragging: Boolean,
+    dragHandleModifier: Modifier,
+    onEnabledChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val info = METRIC_MODULE_REGISTRY.getValue(module.id)
+
+    // "Held" treatment while dragging: a bolder accent border plus a lifted shadow make the
+    // card read as physically picked up. Only the container changes — text and icon tint
+    // logic below is untouched, so contrast/accessibility is unaffected by this state.
+    val borderWidth = if (isDragging) 2.dp else 1.dp
+    val borderColor = if (isDragging) accentColor else Color.White.copy(0.05f)
+    val elevation = if (isDragging) 10.dp else 0.dp
+
+    Row(
+        modifier = modifier
+            .fillMaxSize()
+            .shadow(elevation, RoundedCornerShape(16.dp), clip = false)
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .then(if (isDragging) Modifier.background(accentColor.copy(alpha = 0.08f)) else Modifier)
+            .border(borderWidth, borderColor, RoundedCornerShape(16.dp))
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(modifier = Modifier.size(40.dp).clip(CircleShape).background(MaterialTheme.colorScheme.background), contentAlignment = Alignment.Center) {
+            Icon(info.icon, contentDescription = null, tint = if (module.enabled) accentColor else Color.Gray)
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(info.displayName, color = Color.White, fontWeight = FontWeight.Bold)
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(if (module.enabled) accentColor.copy(0.1f) else MaterialTheme.colorScheme.background)
+                    .padding(horizontal = 6.dp, vertical = 2.dp)
+            ) {
+                Text(info.previewSampleValue, color = if (module.enabled) accentColor else Color.Gray, style = MaterialTheme.typography.labelSmall)
+            }
+        }
+        Switch(
+            checked = module.enabled,
+            onCheckedChange = onEnabledChanged,
+            colors = SwitchDefaults.colors(checkedThumbColor = Color.White, checkedTrackColor = accentColor)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Icon(
+            Icons.Default.DragIndicator,
+            contentDescription = "Drag to reorder",
+            tint = Color.Gray,
+            modifier = dragHandleModifier
+        )
+    }
+}

--- a/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationComponents.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationComponents.kt
@@ -195,7 +195,7 @@ internal fun ModuleRow(
     module: ModuleRowState,
     accentColor: Color,
     isDragging: Boolean,
-    dragHandleModifier: Modifier,
+    dragHandleModifier: Modifier?,
     onEnabledChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier
 ) {
@@ -240,11 +240,16 @@ internal fun ModuleRow(
             colors = SwitchDefaults.colors(checkedThumbColor = Color.White, checkedTrackColor = accentColor)
         )
         Spacer(modifier = Modifier.width(16.dp))
-        Icon(
-            Icons.Default.DragIndicator,
-            contentDescription = "Drag to reorder",
-            tint = Color.Gray,
-            modifier = dragHandleModifier
-        )
+        if (dragHandleModifier != null) {
+            Icon(
+                Icons.Default.DragIndicator,
+                contentDescription = "Drag to reorder",
+                tint = Color.Gray,
+                modifier = dragHandleModifier
+            )
+        } else {
+            Spacer(modifier = Modifier.size(24.dp))
+        }
     }
 }
+

--- a/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
@@ -71,7 +71,7 @@ class OverlayCustomizationViewModel @Inject constructor(
     val useMonospace = settingsRepository.overlayUseMonospace
     val colorIndex = settingsRepository.overlayColorIndex
 
-    fun saveSettings(mode: String, orderedModules: List<ModuleRowState>) {
+    internal fun saveSettings(mode: String, orderedModules: List<ModuleRowState>) {
         settingsRepository.setOverlayMode(mode)
         settingsRepository.setEnabledModules(orderedModules.filter { it.enabled }.map { it.id.storageKey }.toSet())
         settingsRepository.setModuleOrder(orderedModules.map { it.id.storageKey })

--- a/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
@@ -57,7 +57,7 @@ import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 
 /** Editable row state for one metric module: identity plus whether it's shown in the overlay. */
-private data class ModuleRowState(val id: MetricModuleId, val enabled: Boolean)
+internal data class ModuleRowState(val id: MetricModuleId, val enabled: Boolean)
 
 @HiltViewModel
 class OverlayCustomizationViewModel @Inject constructor(

--- a/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBackIosNew
 import androidx.compose.material.icons.filled.RestartAlt

--- a/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
@@ -1,47 +1,63 @@
 package com.framex.app.ui.screens
 
 import android.widget.Toast
-import androidx.compose.ui.platform.LocalContext
-import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.ViewModel
-import com.framex.app.repository.SettingsRepository
-import dagger.hilt.android.lifecycle.HiltViewModel
-import javax.inject.Inject
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBackIosNew
-import androidx.compose.material.icons.filled.DeveloperBoard
-import androidx.compose.material.icons.filled.DeviceThermostat
 import androidx.compose.material.icons.filled.DragIndicator
-import androidx.compose.material.icons.filled.LocalFireDepartment
-import androidx.compose.material.icons.filled.Memory
-import androidx.compose.material.icons.filled.NetworkCheck
-import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material3.*
-import androidx.compose.runtime.*
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Switch
+import androidx.compose.material3.SwitchDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.zIndex
+import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.ViewModel
+import com.framex.app.metrics.METRIC_MODULE_REGISTRY
+import com.framex.app.metrics.MetricModuleId
+import com.framex.app.metrics.resolveMetricModuleOrder
+import com.framex.app.repository.SettingsRepository
+import com.framex.app.ui.components.ReorderableList
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-data class MetricModule(
-    val id: String,
-    val name: String,
-    val previewValue: String,
-    val icon: ImageVector,
-    val enabled: Boolean
-)
+/** Editable row state for one metric module: identity plus whether it's shown in the overlay. */
+private data class ModuleRowState(val id: MetricModuleId, val enabled: Boolean)
 
 @HiltViewModel
 class OverlayCustomizationViewModel @Inject constructor(
@@ -49,14 +65,16 @@ class OverlayCustomizationViewModel @Inject constructor(
 ) : ViewModel() {
     val savedMode = settingsRepository.overlayMode
     val savedModules = settingsRepository.enabledModules
+    val savedModuleOrder = settingsRepository.moduleOrder
     val opacity = settingsRepository.overlayOpacity
     val textSize = settingsRepository.overlayTextSize
     val useMonospace = settingsRepository.overlayUseMonospace
     val colorIndex = settingsRepository.overlayColorIndex
-    
-    fun saveSettings(mode: String, modules: List<MetricModule>) {
+
+    fun saveSettings(mode: String, orderedModules: List<ModuleRowState>) {
         settingsRepository.setOverlayMode(mode)
-        settingsRepository.setEnabledModules(modules.filter { it.enabled }.map { it.id }.toSet())
+        settingsRepository.setEnabledModules(orderedModules.filter { it.enabled }.map { it.id.storageKey }.toSet())
+        settingsRepository.setModuleOrder(orderedModules.map { it.id.storageKey })
     }
 }
 
@@ -67,6 +85,7 @@ fun OverlayCustomizationScreen(
 ) {
     val savedMode by viewModel.savedMode.collectAsState()
     val savedModules by viewModel.savedModules.collectAsState()
+    val savedModuleOrder by viewModel.savedModuleOrder.collectAsState()
     val opacity by viewModel.opacity.collectAsState()
     val textSize by viewModel.textSize.collectAsState()
     val useMonospace by viewModel.useMonospace.collectAsState()
@@ -75,7 +94,7 @@ fun OverlayCustomizationScreen(
 
     var selectedMode by remember(savedMode) { mutableStateOf(savedMode) }
     val modes = listOf("Minimal", "Compact", "Expanded")
-    
+
     val colors = listOf(
         MaterialTheme.colorScheme.primary,
         Color(0xFF60A5FA),
@@ -85,32 +104,25 @@ fun OverlayCustomizationScreen(
         Color(0xFFFBBF24)
     )
     val accentColor = colors[colorIndex]
-    val fontFamily = if (useMonospace) androidx.compose.ui.text.font.FontFamily.Monospace else MaterialTheme.typography.bodyMedium.fontFamily
-    val textScale = when(textSize) { 0 -> 0.8f; 2 -> 1.2f; else -> 1.0f }
+    val fontFamily = if (useMonospace) FontFamily.Monospace else MaterialTheme.typography.bodyMedium.fontFamily
+    val textScale = when (textSize) { 0 -> 0.8f; 2 -> 1.2f; else -> 1.0f }
 
-    var modules by remember(savedModules) {
+    val savedOrderIds = remember(savedModuleOrder) { resolveMetricModuleOrder(savedModuleOrder) }
+
+    var modules by remember(savedModules, savedModuleOrder) {
         mutableStateOf(
-            listOf(
-                MetricModule("fps", "Frames Per Second", "120", Icons.Default.Speed, savedModules.contains("fps")),
-                MetricModule("cpu", "CPU Frequency", "2.8 GHz", Icons.Default.Memory, savedModules.contains("cpu")),
-                MetricModule("cpu_cluster", "CPU Clusters", "U: 2.8G | P: 2.2G | E: 1.6G", Icons.Default.Memory, savedModules.contains("cpu_cluster")),
-                MetricModule("ram", "RAM Usage", "4.2 GB", Icons.Default.DeveloperBoard, savedModules.contains("ram")),
-                MetricModule("temp", "Battery Temp", "38°C", Icons.Default.DeviceThermostat, savedModules.contains("temp")),
-                MetricModule("thermal", "Thermal Monitor", "CPU 63°C · MODERATE", Icons.Default.LocalFireDepartment, savedModules.contains("thermal")),
-                MetricModule("net", "Network Speed", "1.2 MB", Icons.Default.NetworkCheck, savedModules.contains("net"))
-            )
+            savedOrderIds.map { id -> ModuleRowState(id = id, enabled = savedModules.contains(id.storageKey)) }
         )
     }
 
-    val hasChanges = selectedMode != savedMode || modules.filter { it.enabled }.map { it.id }.toSet() != savedModules
+    val hasChanges = selectedMode != savedMode ||
+        modules.map { it.id } != savedOrderIds ||
+        modules.filter { it.enabled }.map { it.id.storageKey }.toSet() != savedModules
 
     Box(modifier = Modifier.fillMaxSize().background(MaterialTheme.colorScheme.background)) {
         Column(modifier = Modifier.fillMaxSize()) {
-            // Header
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(16.dp),
+                modifier = Modifier.fillMaxWidth().padding(16.dp),
                 verticalAlignment = Alignment.CenterVertically
             ) {
                 IconButton(onClick = onNavigateBack) {
@@ -119,157 +131,60 @@ fun OverlayCustomizationScreen(
                 Text("Overlay Config", style = MaterialTheme.typography.titleMedium, color = Color.White)
             }
 
-            LazyColumn(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = 24.dp),
+            ModeSelector(
+                modes = modes,
+                selectedMode = selectedMode,
+                accentColor = accentColor,
+                onModeSelected = { selectedMode = it },
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+            Spacer(modifier = Modifier.height(24.dp))
+
+            OverlayPreviewCard(
+                modules = modules,
+                selectedMode = selectedMode,
+                opacity = opacity,
+                accentColor = accentColor,
+                fontFamily = fontFamily,
+                textScale = textScale,
+                modifier = Modifier.padding(horizontal = 24.dp)
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+
+            Column(modifier = Modifier.padding(horizontal = 24.dp)) {
+                Text("Active Modules", style = MaterialTheme.typography.titleMedium, color = Color.White)
+                Text(
+                    "Drag to reorder. Toggle to show in overlay.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = Color.Gray
+                )
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+
+            ReorderableList(
+                items = modules,
+                key = { it.id.storageKey },
+                onMove = { from, to ->
+                    modules = modules.toMutableList().apply { add(to, removeAt(from)) }
+                },
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
                 contentPadding = PaddingValues(bottom = 100.dp)
-            ) {
-                item {
-                    // Mode Selector
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .clip(CircleShape)
-                            .background(MaterialTheme.colorScheme.surface)
-                            .padding(4.dp)
-                    ) {
-                        modes.forEach { mode ->
-                            Box(
-                                modifier = Modifier
-                                    .weight(1f)
-                                    .clip(CircleShape)
-                                    .background(if (selectedMode == mode) accentColor else Color.Transparent)
-                                    .clickable { selectedMode = mode }
-                                    .padding(vertical = 12.dp),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                Text(
-                                    text = mode,
-                                    color = if (selectedMode == mode) Color.White else Color.Gray,
-                                    fontWeight = FontWeight.Bold
-                                )
-                            }
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(24.dp))
-                }
-
-                item {
-                    // Preview Card
-                    Box(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .height(180.dp)
-                            .clip(RoundedCornerShape(16.dp))
-                            .background(MaterialTheme.colorScheme.surface)
-                            .border(1.dp, Color.White.copy(0.05f), RoundedCornerShape(16.dp))
-                    ) {
-                        Column(modifier = Modifier.padding(16.dp).fillMaxSize(), verticalArrangement = Arrangement.SpaceBetween) {
-                            Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween, verticalAlignment = Alignment.CenterVertically) {
-                                Row(
-                                    modifier = Modifier.clip(RoundedCornerShape(6.dp)).background(MaterialTheme.colorScheme.primary.copy(0.2f)).border(1.dp, MaterialTheme.colorScheme.primary.copy(0.3f), RoundedCornerShape(6.dp)).padding(horizontal = 8.dp, vertical = 4.dp),
-                                    verticalAlignment = Alignment.CenterVertically
-                                ) {
-                                    Box(modifier = Modifier.size(6.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary))
-                                    Spacer(modifier = Modifier.width(6.dp))
-                                    Text("Preview", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold)
-                                }
-                                Text("layout_v2.json", color = Color.Gray, style = MaterialTheme.typography.labelSmall)
-                            }
-                            
-                            // Dynamic Preview Builder
-                            val enabledMods = modules.filter { it.enabled }
-                            
-                            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                                Box(
-                                    modifier = Modifier
-                                        .clip(RoundedCornerShape(8.dp))
-                                        .background(Color.Black.copy(opacity))
-                                        .border(1.dp, accentColor, RoundedCornerShape(8.dp))
-                                        .padding(if (selectedMode == "Minimal") (4 * textScale).dp else (8 * textScale).dp)
-                                ) {
-                                    if (selectedMode == "Expanded") {
-                                        Column(verticalArrangement = Arrangement.spacedBy((8 * textScale).dp)) {
-                                            enabledMods.forEach { mod ->
-                                                Row(verticalAlignment = Alignment.CenterVertically) {
-                                                    Icon(mod.icon, contentDescription = null, tint = accentColor, modifier = Modifier.size((16 * textScale).dp))
-                                                    Spacer(modifier = Modifier.width((8 * textScale).dp))
-                                                    Text(mod.name, color = Color.Gray, fontSize = (10 * textScale).sp, fontFamily = fontFamily, modifier = Modifier.weight(1f))
-                                                    Text(mod.previewValue, color = Color.White, fontFamily = fontFamily, style = MaterialTheme.typography.labelSmall.copy(fontSize = (12 * textScale).sp, fontWeight = FontWeight.Bold))
-                                                }
-                                            }
-                                        }
-                                    } else {
-                                        Row(
-                                            horizontalArrangement = Arrangement.spacedBy((12 * textScale).dp),
-                                            verticalAlignment = Alignment.CenterVertically,
-                                            modifier = Modifier.padding(horizontal = (4 * textScale).dp)
-                                        ) {
-                                            enabledMods.forEachIndexed { index, mod ->
-                                                if (selectedMode == "Minimal") {
-                                                    Text(mod.previewValue, color = Color.White, fontFamily = fontFamily, style = MaterialTheme.typography.labelSmall.copy(fontSize = (14 * textScale).sp, fontWeight = FontWeight.Bold))
-                                                } else {
-                                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                                        Text(mod.id.uppercase(), color = Color.Gray, fontFamily = fontFamily, fontSize = (10 * textScale).sp, fontWeight = FontWeight.Bold)
-                                                        Text(mod.previewValue, color = if (index == 0) accentColor else Color.White, fontFamily = fontFamily, style = MaterialTheme.typography.labelSmall.copy(fontSize = (16 * textScale).sp, fontWeight = FontWeight.Bold))
-                                                    }
-                                                }
-                                                if (index < enabledMods.size - 1) {
-                                                    Box(modifier = Modifier.width(1.dp).height(if (selectedMode == "Minimal") (12 * textScale).dp else (24 * textScale).dp).background(Color.DarkGray))
-                                                }
-                                            }
-                                            if (enabledMods.isEmpty()) {
-                                                Text("No modules selected", color = Color.Gray, fontFamily = fontFamily, fontSize = (12 * textScale).sp)
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                    Spacer(modifier = Modifier.height(32.dp))
-                    Text("Active Modules", style = MaterialTheme.typography.titleMedium, color = Color.White)
-                    Text("Drag to reorder. Toggle to show in overlay.", style = MaterialTheme.typography.bodySmall, color = Color.Gray)
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
-
-                items(modules) { module ->
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(bottom = 12.dp)
-                            .clip(RoundedCornerShape(16.dp))
-                            .background(MaterialTheme.colorScheme.surface)
-                            .border(1.dp, Color.White.copy(0.05f), RoundedCornerShape(16.dp))
-                            .padding(16.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        Box(modifier = Modifier.size(40.dp).clip(CircleShape).background(MaterialTheme.colorScheme.background), contentAlignment = Alignment.Center) {
-                            Icon(module.icon, contentDescription = null, tint = if (module.enabled) accentColor else Color.Gray)
-                        }
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Column(modifier = Modifier.weight(1f)) {
-                            Text(module.name, color = Color.White, fontWeight = FontWeight.Bold)
-                            Box(modifier = Modifier.clip(RoundedCornerShape(4.dp)).background(if(module.enabled) accentColor.copy(0.1f) else MaterialTheme.colorScheme.background).padding(horizontal = 6.dp, vertical = 2.dp)) {
-                                Text(module.previewValue, color = if(module.enabled) accentColor else Color.Gray, style = MaterialTheme.typography.labelSmall)
-                            }
-                        }
-                        Switch(
-                            checked = module.enabled,
-                            onCheckedChange = { isChecked ->
-                                modules = modules.map { if (it.id == module.id) it.copy(enabled = isChecked) else it }
-                            },
-                            colors = SwitchDefaults.colors(checkedThumbColor = Color.White, checkedTrackColor = accentColor)
-                        )
-                        Spacer(modifier = Modifier.width(16.dp))
-                        Icon(Icons.Default.DragIndicator, contentDescription = "Drag", tint = Color.Gray)
-                    }
-                }
+            ) { module, dragHandleModifier, dragOffsetPx ->
+                ModuleRow(
+                    module = module,
+                    accentColor = accentColor,
+                    dragHandleModifier = dragHandleModifier,
+                    onEnabledChanged = { isChecked ->
+                        modules = modules.map { if (it.id == module.id) it.copy(enabled = isChecked) else it }
+                    },
+                    modifier = Modifier
+                        .padding(bottom = 12.dp)
+                        .graphicsLayer { translationY = dragOffsetPx }
+                        .zIndex(if (dragOffsetPx != 0f) 1f else 0f)
+                )
             }
         }
-        
-        // Bottom Action
+
         Box(
             modifier = Modifier
                 .align(Alignment.BottomCenter)
@@ -278,7 +193,7 @@ fun OverlayCustomizationScreen(
                 .padding(24.dp)
         ) {
             Button(
-                onClick = { 
+                onClick = {
                     if (hasChanges) {
                         viewModel.saveSettings(selectedMode, modules)
                         Toast.makeText(context, "Overlay configuration saved!", Toast.LENGTH_SHORT).show()
@@ -286,7 +201,7 @@ fun OverlayCustomizationScreen(
                 },
                 enabled = hasChanges,
                 colors = ButtonDefaults.buttonColors(
-                    containerColor = accentColor, 
+                    containerColor = accentColor,
                     contentColor = Color.White,
                     disabledContainerColor = Color.DarkGray.copy(alpha = 0.5f),
                     disabledContentColor = Color.Gray
@@ -297,5 +212,202 @@ fun OverlayCustomizationScreen(
                 Text(if (hasChanges) "Apply Changes" else "Applied", fontWeight = FontWeight.Bold)
             }
         }
+    }
+}
+
+@Composable
+private fun ModeSelector(
+    modes: List<String>,
+    selectedMode: String,
+    accentColor: Color,
+    onModeSelected: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(CircleShape)
+            .background(MaterialTheme.colorScheme.surface)
+            .padding(4.dp)
+    ) {
+        modes.forEach { mode ->
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .clip(CircleShape)
+                    .background(if (selectedMode == mode) accentColor else Color.Transparent)
+                    .clickable { onModeSelected(mode) }
+                    .padding(vertical = 12.dp),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = mode,
+                    color = if (selectedMode == mode) Color.White else Color.Gray,
+                    fontWeight = FontWeight.Bold
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun OverlayPreviewCard(
+    modules: List<ModuleRowState>,
+    selectedMode: String,
+    opacity: Float,
+    accentColor: Color,
+    fontFamily: FontFamily?,
+    textScale: Float,
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(180.dp)
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .border(1.dp, Color.White.copy(0.05f), RoundedCornerShape(16.dp))
+    ) {
+        Column(modifier = Modifier.padding(16.dp).fillMaxSize(), verticalArrangement = Arrangement.SpaceBetween) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Row(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(6.dp))
+                        .background(MaterialTheme.colorScheme.primary.copy(0.2f))
+                        .border(1.dp, MaterialTheme.colorScheme.primary.copy(0.3f), RoundedCornerShape(6.dp))
+                        .padding(horizontal = 8.dp, vertical = 4.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Box(modifier = Modifier.size(6.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary))
+                    Spacer(modifier = Modifier.width(6.dp))
+                    Text("Preview", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold)
+                }
+                Text("layout_v2.json", color = Color.Gray, style = MaterialTheme.typography.labelSmall)
+            }
+
+            // Preview order always mirrors the live `modules` list state above, so what's
+            // shown here matches exactly what the overlay will render once applied.
+            val enabledModules = modules.filter { it.enabled }
+
+            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                Box(
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(8.dp))
+                        .background(Color.Black.copy(opacity))
+                        .border(1.dp, accentColor, RoundedCornerShape(8.dp))
+                        .padding(if (selectedMode == "Minimal") (4 * textScale).dp else (8 * textScale).dp)
+                ) {
+                    if (selectedMode == "Expanded") {
+                        Column(verticalArrangement = Arrangement.spacedBy((8 * textScale).dp)) {
+                            enabledModules.forEach { module ->
+                                val info = METRIC_MODULE_REGISTRY.getValue(module.id)
+                                Row(verticalAlignment = Alignment.CenterVertically) {
+                                    Icon(info.icon, contentDescription = null, tint = accentColor, modifier = Modifier.size((16 * textScale).dp))
+                                    Spacer(modifier = Modifier.width((8 * textScale).dp))
+                                    Text(info.displayName, color = Color.Gray, fontSize = (10 * textScale).sp, fontFamily = fontFamily, modifier = Modifier.weight(1f))
+                                    Text(
+                                        info.previewSampleValue,
+                                        color = Color.White,
+                                        fontFamily = fontFamily,
+                                        style = MaterialTheme.typography.labelSmall.copy(fontSize = (12 * textScale).sp, fontWeight = FontWeight.Bold)
+                                    )
+                                }
+                            }
+                        }
+                    } else {
+                        Row(
+                            horizontalArrangement = Arrangement.spacedBy((12 * textScale).dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            modifier = Modifier.padding(horizontal = (4 * textScale).dp)
+                        ) {
+                            enabledModules.forEachIndexed { index, module ->
+                                val info = METRIC_MODULE_REGISTRY.getValue(module.id)
+                                if (selectedMode == "Minimal") {
+                                    Text(
+                                        info.previewSampleValue,
+                                        color = Color.White,
+                                        fontFamily = fontFamily,
+                                        style = MaterialTheme.typography.labelSmall.copy(fontSize = (14 * textScale).sp, fontWeight = FontWeight.Bold)
+                                    )
+                                } else {
+                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
+                                        Text(module.id.storageKey.uppercase(), color = Color.Gray, fontFamily = fontFamily, fontSize = (10 * textScale).sp, fontWeight = FontWeight.Bold)
+                                        Text(
+                                            info.previewSampleValue,
+                                            color = if (index == 0) accentColor else Color.White,
+                                            fontFamily = fontFamily,
+                                            style = MaterialTheme.typography.labelSmall.copy(fontSize = (16 * textScale).sp, fontWeight = FontWeight.Bold)
+                                        )
+                                    }
+                                }
+                                if (index < enabledModules.size - 1) {
+                                    Box(
+                                        modifier = Modifier
+                                            .width(1.dp)
+                                            .height(if (selectedMode == "Minimal") (12 * textScale).dp else (24 * textScale).dp)
+                                            .background(Color.DarkGray)
+                                    )
+                                }
+                            }
+                            if (enabledModules.isEmpty()) {
+                                Text("No modules selected", color = Color.Gray, fontFamily = fontFamily, fontSize = (12 * textScale).sp)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ModuleRow(
+    module: ModuleRowState,
+    accentColor: Color,
+    dragHandleModifier: Modifier,
+    onEnabledChanged: (Boolean) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val info = METRIC_MODULE_REGISTRY.getValue(module.id)
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(16.dp))
+            .background(MaterialTheme.colorScheme.surface)
+            .border(1.dp, Color.White.copy(0.05f), RoundedCornerShape(16.dp))
+            .padding(16.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Box(modifier = Modifier.size(40.dp).clip(CircleShape).background(MaterialTheme.colorScheme.background), contentAlignment = Alignment.Center) {
+            Icon(info.icon, contentDescription = null, tint = if (module.enabled) accentColor else Color.Gray)
+        }
+        Spacer(modifier = Modifier.width(16.dp))
+        Column(modifier = Modifier.weight(1f)) {
+            Text(info.displayName, color = Color.White, fontWeight = FontWeight.Bold)
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(4.dp))
+                    .background(if (module.enabled) accentColor.copy(0.1f) else MaterialTheme.colorScheme.background)
+                    .padding(horizontal = 6.dp, vertical = 2.dp)
+            ) {
+                Text(info.previewSampleValue, color = if (module.enabled) accentColor else Color.Gray, style = MaterialTheme.typography.labelSmall)
+            }
+        }
+        Switch(
+            checked = module.enabled,
+            onCheckedChange = onEnabledChanged,
+            colors = SwitchDefaults.colors(checkedThumbColor = Color.White, checkedTrackColor = accentColor)
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Icon(
+            Icons.Default.DragIndicator,
+            contentDescription = "Drag to reorder",
+            tint = Color.Gray,
+            modifier = dragHandleModifier
+        )
     }
 }

--- a/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
@@ -101,7 +101,11 @@ fun OverlayCustomizationScreen(
     val fontFamily = if (useMonospace) FontFamily.Monospace else MaterialTheme.typography.bodyMedium.fontFamily
     val textScale = when (textSize) { 0 -> 0.8f; 2 -> 1.2f; else -> 1.0f }
 
-    val savedOrderIds = remember(savedModuleOrder) { resolveMetricModuleOrder(savedModuleOrder) }
+    val savedOrderIds = remember(savedModuleOrder) {
+        val resolved = resolveMetricModuleOrder(savedModuleOrder)
+        val withoutFps = resolved.filter { it != MetricModuleId.FPS }
+        listOf(MetricModuleId.FPS) + withoutFps
+    }
 
     var modules by remember(savedModules, savedModuleOrder) {
         mutableStateOf(
@@ -176,6 +180,7 @@ fun OverlayCustomizationScreen(
                 key = { it.id.storageKey },
                 itemHeight = MODULE_ROW_HEIGHT,
                 itemSpacing = MODULE_ROW_SPACING,
+                minReorderIndex = 1,
                 onMove = { from, to ->
                     modules = modules.toMutableList().apply { add(to, removeAt(from)) }
                 },

--- a/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
@@ -2,9 +2,6 @@ package com.framex.app.ui.screens
 
 import android.widget.Toast
 import androidx.compose.foundation.background
-import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -14,20 +11,14 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.CircleShape
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBackIosNew
-import androidx.compose.material.icons.filled.DragIndicator
+import androidx.compose.material.icons.filled.RestartAlt
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -37,18 +28,14 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
-import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.ViewModel
-import com.framex.app.metrics.METRIC_MODULE_REGISTRY
+import com.framex.app.metrics.DEFAULT_METRIC_MODULE_ORDER
 import com.framex.app.metrics.MetricModuleId
 import com.framex.app.metrics.resolveMetricModuleOrder
 import com.framex.app.repository.SettingsRepository
@@ -58,6 +45,12 @@ import javax.inject.Inject
 
 /** Editable row state for one metric module: identity plus whether it's shown in the overlay. */
 internal data class ModuleRowState(val id: MetricModuleId, val enabled: Boolean)
+
+/** Exact rendered height every module row must occupy — see ReorderableList's itemHeight contract. */
+private val MODULE_ROW_HEIGHT = 84.dp
+
+/** Vertical gap below each module row. */
+private val MODULE_ROW_SPACING = 12.dp
 
 @HiltViewModel
 class OverlayCustomizationViewModel @Inject constructor(
@@ -151,36 +144,51 @@ fun OverlayCustomizationScreen(
             )
             Spacer(modifier = Modifier.height(32.dp))
 
-            Column(modifier = Modifier.padding(horizontal = 24.dp)) {
-                Text("Active Modules", style = MaterialTheme.typography.titleMedium, color = Color.White)
-                Text(
-                    "Drag to reorder. Toggle to show in overlay.",
-                    style = MaterialTheme.typography.bodySmall,
-                    color = Color.Gray
-                )
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text("Active Modules", style = MaterialTheme.typography.titleMedium, color = Color.White)
+                    Text(
+                        "Drag to reorder. Toggle to show in overlay.",
+                        style = MaterialTheme.typography.bodySmall,
+                        color = Color.Gray
+                    )
+                }
+                IconButton(
+                    onClick = {
+                        val enabledById = modules.associate { it.id to it.enabled }
+                        modules = DEFAULT_METRIC_MODULE_ORDER.map { id ->
+                            ModuleRowState(id = id, enabled = enabledById[id] ?: false)
+                        }
+                        Toast.makeText(context, "Order reset to default", Toast.LENGTH_SHORT).show()
+                    }
+                ) {
+                    Icon(Icons.Default.RestartAlt, contentDescription = "Reset to default order", tint = Color.Gray)
+                }
             }
             Spacer(modifier = Modifier.height(16.dp))
 
             ReorderableList(
                 items = modules,
                 key = { it.id.storageKey },
+                itemHeight = MODULE_ROW_HEIGHT,
+                itemSpacing = MODULE_ROW_SPACING,
                 onMove = { from, to ->
                     modules = modules.toMutableList().apply { add(to, removeAt(from)) }
                 },
                 modifier = Modifier.fillMaxWidth().padding(horizontal = 24.dp),
                 contentPadding = PaddingValues(bottom = 100.dp)
-            ) { module, dragHandleModifier, dragOffsetPx ->
+            ) { module, dragHandleModifier, isDragging ->
                 ModuleRow(
                     module = module,
                     accentColor = accentColor,
+                    isDragging = isDragging,
                     dragHandleModifier = dragHandleModifier,
                     onEnabledChanged = { isChecked ->
                         modules = modules.map { if (it.id == module.id) it.copy(enabled = isChecked) else it }
-                    },
-                    modifier = Modifier
-                        .padding(bottom = 12.dp)
-                        .graphicsLayer { translationY = dragOffsetPx }
-                        .zIndex(if (dragOffsetPx != 0f) 1f else 0f)
+                    }
                 )
             }
         }
@@ -215,199 +223,3 @@ fun OverlayCustomizationScreen(
     }
 }
 
-@Composable
-private fun ModeSelector(
-    modes: List<String>,
-    selectedMode: String,
-    accentColor: Color,
-    onModeSelected: (String) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(CircleShape)
-            .background(MaterialTheme.colorScheme.surface)
-            .padding(4.dp)
-    ) {
-        modes.forEach { mode ->
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .clip(CircleShape)
-                    .background(if (selectedMode == mode) accentColor else Color.Transparent)
-                    .clickable { onModeSelected(mode) }
-                    .padding(vertical = 12.dp),
-                contentAlignment = Alignment.Center
-            ) {
-                Text(
-                    text = mode,
-                    color = if (selectedMode == mode) Color.White else Color.Gray,
-                    fontWeight = FontWeight.Bold
-                )
-            }
-        }
-    }
-}
-
-@Composable
-private fun OverlayPreviewCard(
-    modules: List<ModuleRowState>,
-    selectedMode: String,
-    opacity: Float,
-    accentColor: Color,
-    fontFamily: FontFamily?,
-    textScale: Float,
-    modifier: Modifier = Modifier
-) {
-    Box(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(180.dp)
-            .clip(RoundedCornerShape(16.dp))
-            .background(MaterialTheme.colorScheme.surface)
-            .border(1.dp, Color.White.copy(0.05f), RoundedCornerShape(16.dp))
-    ) {
-        Column(modifier = Modifier.padding(16.dp).fillMaxSize(), verticalArrangement = Arrangement.SpaceBetween) {
-            Row(
-                modifier = Modifier.fillMaxWidth(),
-                horizontalArrangement = Arrangement.SpaceBetween,
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                Row(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(6.dp))
-                        .background(MaterialTheme.colorScheme.primary.copy(0.2f))
-                        .border(1.dp, MaterialTheme.colorScheme.primary.copy(0.3f), RoundedCornerShape(6.dp))
-                        .padding(horizontal = 8.dp, vertical = 4.dp),
-                    verticalAlignment = Alignment.CenterVertically
-                ) {
-                    Box(modifier = Modifier.size(6.dp).clip(CircleShape).background(MaterialTheme.colorScheme.primary))
-                    Spacer(modifier = Modifier.width(6.dp))
-                    Text("Preview", color = MaterialTheme.colorScheme.primary, fontSize = 10.sp, fontWeight = FontWeight.Bold)
-                }
-                Text("layout_v2.json", color = Color.Gray, style = MaterialTheme.typography.labelSmall)
-            }
-
-            // Preview order always mirrors the live `modules` list state above, so what's
-            // shown here matches exactly what the overlay will render once applied.
-            val enabledModules = modules.filter { it.enabled }
-
-            Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
-                Box(
-                    modifier = Modifier
-                        .clip(RoundedCornerShape(8.dp))
-                        .background(Color.Black.copy(opacity))
-                        .border(1.dp, accentColor, RoundedCornerShape(8.dp))
-                        .padding(if (selectedMode == "Minimal") (4 * textScale).dp else (8 * textScale).dp)
-                ) {
-                    if (selectedMode == "Expanded") {
-                        Column(verticalArrangement = Arrangement.spacedBy((8 * textScale).dp)) {
-                            enabledModules.forEach { module ->
-                                val info = METRIC_MODULE_REGISTRY.getValue(module.id)
-                                Row(verticalAlignment = Alignment.CenterVertically) {
-                                    Icon(info.icon, contentDescription = null, tint = accentColor, modifier = Modifier.size((16 * textScale).dp))
-                                    Spacer(modifier = Modifier.width((8 * textScale).dp))
-                                    Text(info.displayName, color = Color.Gray, fontSize = (10 * textScale).sp, fontFamily = fontFamily, modifier = Modifier.weight(1f))
-                                    Text(
-                                        info.previewSampleValue,
-                                        color = Color.White,
-                                        fontFamily = fontFamily,
-                                        style = MaterialTheme.typography.labelSmall.copy(fontSize = (12 * textScale).sp, fontWeight = FontWeight.Bold)
-                                    )
-                                }
-                            }
-                        }
-                    } else {
-                        Row(
-                            horizontalArrangement = Arrangement.spacedBy((12 * textScale).dp),
-                            verticalAlignment = Alignment.CenterVertically,
-                            modifier = Modifier.padding(horizontal = (4 * textScale).dp)
-                        ) {
-                            enabledModules.forEachIndexed { index, module ->
-                                val info = METRIC_MODULE_REGISTRY.getValue(module.id)
-                                if (selectedMode == "Minimal") {
-                                    Text(
-                                        info.previewSampleValue,
-                                        color = Color.White,
-                                        fontFamily = fontFamily,
-                                        style = MaterialTheme.typography.labelSmall.copy(fontSize = (14 * textScale).sp, fontWeight = FontWeight.Bold)
-                                    )
-                                } else {
-                                    Column(horizontalAlignment = Alignment.CenterHorizontally) {
-                                        Text(module.id.storageKey.uppercase(), color = Color.Gray, fontFamily = fontFamily, fontSize = (10 * textScale).sp, fontWeight = FontWeight.Bold)
-                                        Text(
-                                            info.previewSampleValue,
-                                            color = if (index == 0) accentColor else Color.White,
-                                            fontFamily = fontFamily,
-                                            style = MaterialTheme.typography.labelSmall.copy(fontSize = (16 * textScale).sp, fontWeight = FontWeight.Bold)
-                                        )
-                                    }
-                                }
-                                if (index < enabledModules.size - 1) {
-                                    Box(
-                                        modifier = Modifier
-                                            .width(1.dp)
-                                            .height(if (selectedMode == "Minimal") (12 * textScale).dp else (24 * textScale).dp)
-                                            .background(Color.DarkGray)
-                                    )
-                                }
-                            }
-                            if (enabledModules.isEmpty()) {
-                                Text("No modules selected", color = Color.Gray, fontFamily = fontFamily, fontSize = (12 * textScale).sp)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-}
-
-@Composable
-private fun ModuleRow(
-    module: ModuleRowState,
-    accentColor: Color,
-    dragHandleModifier: Modifier,
-    onEnabledChanged: (Boolean) -> Unit,
-    modifier: Modifier = Modifier
-) {
-    val info = METRIC_MODULE_REGISTRY.getValue(module.id)
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .clip(RoundedCornerShape(16.dp))
-            .background(MaterialTheme.colorScheme.surface)
-            .border(1.dp, Color.White.copy(0.05f), RoundedCornerShape(16.dp))
-            .padding(16.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        Box(modifier = Modifier.size(40.dp).clip(CircleShape).background(MaterialTheme.colorScheme.background), contentAlignment = Alignment.Center) {
-            Icon(info.icon, contentDescription = null, tint = if (module.enabled) accentColor else Color.Gray)
-        }
-        Spacer(modifier = Modifier.width(16.dp))
-        Column(modifier = Modifier.weight(1f)) {
-            Text(info.displayName, color = Color.White, fontWeight = FontWeight.Bold)
-            Box(
-                modifier = Modifier
-                    .clip(RoundedCornerShape(4.dp))
-                    .background(if (module.enabled) accentColor.copy(0.1f) else MaterialTheme.colorScheme.background)
-                    .padding(horizontal = 6.dp, vertical = 2.dp)
-            ) {
-                Text(info.previewSampleValue, color = if (module.enabled) accentColor else Color.Gray, style = MaterialTheme.typography.labelSmall)
-            }
-        }
-        Switch(
-            checked = module.enabled,
-            onCheckedChange = onEnabledChanged,
-            colors = SwitchDefaults.colors(checkedThumbColor = Color.White, checkedTrackColor = accentColor)
-        )
-        Spacer(modifier = Modifier.width(16.dp))
-        Icon(
-            Icons.Default.DragIndicator,
-            contentDescription = "Drag to reorder",
-            tint = Color.Gray,
-            modifier = dragHandleModifier
-        )
-    }
-}


### PR DESCRIPTION
## Fixes #16

### Root cause (two compounding bugs)

1. **No drag gesture existed.** The 6-dot `DragIndicator` icon in `OverlayCustomizationScreen` was purely decorative — nothing was wired to it (no `pointerInput`, no drag detection at all).
2. **Order couldn't have persisted even if dragging worked.** Enabled modules are stored as a `Set<String>` (`SharedPreferences` `StringSet`), which has **no guaranteed iteration order**. On top of that, `OverlayManager` and `AppearanceScreen` each rendered from their own **hardcoded, fixed-order arrays** (the same list duplicated 3 times) — so the live overlay and the Appearance preview were always going to show modules in that one fixed order regardless of anything the config screen did. As a bonus find, `AppearanceScreen`'s copy of the array was missing `cpu_cluster` and `thermal` entirely, silently dropping those modules from that screen's preview.

### What this PR does

- **`metrics/MetricModule.kt` (new)** — single source of truth for module identity (id, display name, icon, overlay short label, preview sample value), the canonical default order, and `resolveMetricModuleOrder()`, which reconciles a user's persisted order against the current module set (drops unknown/stale keys, appends any module introduced in a later update). Replaces the three duplicated hardcoded arrays.
- **`ui/components/ReorderableList.kt` (new)** — a generic, reusable handle-driven drag-to-reorder `LazyColumn` wrapper with autoscroll near the viewport edges. Only the drag handle initiates a drag, so the rest of the row keeps its normal toggle behavior.
- **`repository/SettingsRepository.kt`** — persists module order as a delimited string (`moduleOrder: StateFlow<List<String>>` + `setModuleOrder()`), since `StringSet` can't preserve order.
- **`ui/screens/OverlayCustomizationScreen.kt`** — real drag-and-drop wired via `ReorderableList`; Apply now persists both the enabled set *and* the order.
- **`overlay/OverlayManager.kt`** — the live overlay now renders modules in the user's persisted order instead of the old fixed array.
- **`ui/screens/AppearanceScreen.kt`** — its preview now derives from the same registry + persisted order, so it always matches the real overlay (and no longer silently drops `cpu_cluster`/`thermal`).

### Behavior

- Long-press-free drag: touching the 6-dot handle and dragging immediately starts reordering (no long-press delay, since the handle is a dedicated affordance).
- Reordering in Overlay Config now directly determines the order modules appear in the live overlay, per the original ask — e.g. moving FPS to the top of the config list puts FPS first in the overlay.
- Order and enabled-state changes are both tracked by the existing "Apply Changes" dirty-check, and both are only written on Apply (not live per-drag), matching the screen's existing save model.
- Autoscroll is included for the case where the module list doesn't fully fit the viewport.