### PR TITLE
Fix #15: Fix thermal diagnostics readings and live top process

### DIFF
--- a/app/src/main/java/com/framex/app/metrics/CpuInfoTopParser.kt
+++ b/app/src/main/java/com/framex/app/metrics/CpuInfoTopParser.kt
@@ -1,0 +1,25 @@
+package com.framex.app.metrics
+
+/**
+ * Pure parser for the busiest process line in `dumpsys cpuinfo` output.
+ * Same package-level style as [CpuStatParser] — no Android deps.
+ */
+internal object CpuInfoTopParser {
+
+    data class TopProcess(val name: String, val cpuPercent: Float)
+
+    // e.g. "  23% 1234/com.example.app: 15% user + 8% kernel"
+    private val lineRegex = Regex("""^\s*([0-9.]+)%\s+\d+/([^:]+):""")
+
+    fun parseTop(output: String): TopProcess? {
+        if (output.isBlank()) return null
+        for (line in output.lineSequence()) {
+            val match = lineRegex.find(line) ?: continue
+            val pct = match.groupValues[1].toFloatOrNull() ?: continue
+            val name = match.groupValues[2].trim()
+            if (name.equals("TOTAL", ignoreCase = true)) continue
+            return TopProcess(name, pct)
+        }
+        return null
+    }
+}

--- a/app/src/main/java/com/framex/app/metrics/MetricReadStatus.kt
+++ b/app/src/main/java/com/framex/app/metrics/MetricReadStatus.kt
@@ -1,0 +1,28 @@
+package com.framex.app.metrics
+
+/**
+ * Readiness of a diagnostic channel (thermal sensors, top process, etc.).
+ * Lets the UI distinguish "real zero / real value" from "we could not read".
+ */
+enum class MetricReadStatus {
+    /** First poll has not completed yet. */
+    Loading,
+
+    /** Parsed usable data on this cycle. */
+    Ok,
+
+    /** Shizuku binder missing or permission not granted. */
+    NoShizuku,
+
+    /** Command ran but returned blank output. */
+    EmptyOutput,
+
+    /** Non-blank dump that did not match any known entries. */
+    ParseFailed,
+
+    /** Channel is live but this sample/sensor has nothing to show. */
+    NoData,
+
+    /** Showing last successful sample after a short run of failures. */
+    Stale
+}

--- a/app/src/main/java/com/framex/app/metrics/MetricsEngine.kt
+++ b/app/src/main/java/com/framex/app/metrics/MetricsEngine.kt
@@ -33,10 +33,17 @@ data class MetricsState(
     val thermalNpuC: Float = 0f,
     val thermalSkinC: Float = 0f,
     val thermalStatus: Int = 0,
+    val thermalReadStatus: MetricReadStatus = MetricReadStatus.Loading,
+    val hasThermalCpu: Boolean = false,
+    val hasThermalGpu: Boolean = false,
+    val hasThermalNpu: Boolean = false,
+    val hasThermalSkin: Boolean = false,
+    val hasThermalBattery: Boolean = false,
     // Busiest process at this tick (see TopProcessMonitor) — names the likely
     // culprit when a frame drop isn't explained by thermal or frequency alone.
     val topProcessName: String? = null,
-    val topProcessCpuPercent: Float = 0f
+    val topProcessCpuPercent: Float = 0f,
+    val topProcessReadStatus: MetricReadStatus = MetricReadStatus.Loading
 )
 
 @Singleton
@@ -176,7 +183,13 @@ class MetricsEngine @Inject constructor(
                             thermalGpuC = t.gpuC,
                             thermalNpuC = t.npuC,
                             thermalSkinC = t.skinC,
-                            thermalStatus = t.status
+                            thermalStatus = t.status,
+                            thermalReadStatus = t.readStatus,
+                            hasThermalCpu = t.hasCpu,
+                            hasThermalGpu = t.hasGpu,
+                            hasThermalNpu = t.hasNpu,
+                            hasThermalSkin = t.hasSkin,
+                            hasThermalBattery = t.hasBattery
                         )
                     }
                 }
@@ -188,8 +201,9 @@ class MetricsEngine @Inject constructor(
                 toggleModule("top_process", enabled) {
                     topProcessMonitor.topProcess.collect { top ->
                         _metricsState.value = _metricsState.value.copy(
-                            topProcessName = top?.name,
-                            topProcessCpuPercent = top?.cpuPercent ?: 0f
+                            topProcessName = if (top.readStatus == MetricReadStatus.Ok) top.name else null,
+                            topProcessCpuPercent = top.cpuPercent,
+                            topProcessReadStatus = top.readStatus
                         )
                     }
                 }
@@ -218,10 +232,16 @@ class MetricsEngine @Inject constructor(
                 "temp"    -> _metricsState.value.copy(batteryTempC = 0f)
                 "thermal" -> _metricsState.value.copy(
                     thermalCpuC = 0f, thermalGpuC = 0f, thermalNpuC = 0f,
-                    thermalSkinC = 0f, thermalStatus = 0
+                    thermalSkinC = 0f, thermalStatus = 0,
+                    thermalReadStatus = MetricReadStatus.Loading,
+                    hasThermalCpu = false, hasThermalGpu = false, hasThermalNpu = false,
+                    hasThermalSkin = false, hasThermalBattery = false
                 )
                 "ping"    -> _metricsState.value.copy(pingMs = 0)
-                "top_process" -> _metricsState.value.copy(topProcessName = null, topProcessCpuPercent = 0f)
+                "top_process" -> _metricsState.value.copy(
+                    topProcessName = null, topProcessCpuPercent = 0f,
+                    topProcessReadStatus = MetricReadStatus.Loading
+                )
                 else      -> _metricsState.value
             }
         }

--- a/app/src/main/java/com/framex/app/metrics/Monitors.kt
+++ b/app/src/main/java/com/framex/app/metrics/Monitors.kt
@@ -414,20 +414,19 @@ class ThermalMonitor @Inject constructor(
     @ApplicationContext private val context: Context,
     private val shizukuManager: ShizukuManager
 ) {
-    // Full breakdown from `dumpsys thermalservice`. This is the same data source
-    // Android's own throttling decisions are based on, so it explains WHY frames
-    // drop, not just THAT they drop. Reading it needs no special permission beyond
-    // normal shell (works via Shizuku or even plain adb) since it goes through the
-    // ThermalService binder call, not raw /sys reads (which are often root-gated
-    // on OEM builds — e.g. thermal_zone*/temp is root-only on some Vivo firmware).
     data class ThermalState(
         val cpuC: Float = 0f,
         val gpuC: Float = 0f,
         val npuC: Float = 0f,
         val skinC: Float = 0f,
         val batteryC: Float = 0f,
-        // Android thermal status: 0=NONE 1=LIGHT 2=MODERATE 3=SEVERE 4=CRITICAL 5=EMERGENCY 6=SHUTDOWN
-        val status: Int = 0
+        val status: Int = 0,
+        val readStatus: MetricReadStatus = MetricReadStatus.Loading,
+        val hasCpu: Boolean = false,
+        val hasGpu: Boolean = false,
+        val hasNpu: Boolean = false,
+        val hasSkin: Boolean = false,
+        val hasBattery: Boolean = false
     ) {
         val statusLabel: String get() = when (status) {
             0 -> "NONE"; 1 -> "LIGHT"; 2 -> "MODERATE"; 3 -> "SEVERE"
@@ -435,15 +434,11 @@ class ThermalMonitor @Inject constructor(
         }
     }
 
-    // "Current temperatures from HAL:" block looks like:
-    //   Temperature{mValue=62.895, mType=0, mName=CPU, mStatus=0}
-    // mType per Android's Temperature.java: 0=CPU 1=GPU 2=BATTERY 3=SKIN 5=POWER_AMPLIFIER 9=NPU
-    private val entryRegex = Regex(
-        "Temperature\\{mValue=(-?[0-9.]+),\\s*mType=(\\d+),\\s*mName=([A-Z_]+)"
-    )
-
     val thermalState: Flow<ThermalState> = flow {
         val powerManager = context.getSystemService(Context.POWER_SERVICE) as PowerManager
+        var lastGoodState: ThermalState? = null
+        var consecutiveFailures = 0
+
         while (true) {
             val shizukuReady = shizukuManager.isShizukuAvailable.value &&
                     shizukuManager.hasPermission.value
@@ -451,54 +446,79 @@ class ThermalMonitor @Inject constructor(
             val state = if (shizukuReady) {
                 try {
                     val output = shizukuManager.executeCommand("dumpsys thermalservice")
-                    parseThermalService(output) ?: fallbackState(powerManager)
+                    if (output.isBlank()) {
+                        consecutiveFailures++
+                        if (consecutiveFailures <= 3 && lastGoodState != null) {
+                            lastGoodState.copy(readStatus = MetricReadStatus.Stale)
+                        } else {
+                            if (consecutiveFailures > 3) {
+                                lastGoodState = null
+                            }
+                            val status = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                                powerManager.currentThermalStatus
+                            } else 0
+                            ThermalState(status = status, readStatus = MetricReadStatus.EmptyOutput)
+                        }
+                    } else {
+                        val parsed = ThermalServiceParser.parse(output)
+                        if (parsed == null || parsed.entryCount == 0) {
+                            consecutiveFailures++
+                            if (consecutiveFailures <= 3 && lastGoodState != null) {
+                                lastGoodState.copy(readStatus = MetricReadStatus.Stale)
+                            } else {
+                                if (consecutiveFailures > 3) {
+                                    lastGoodState = null
+                                }
+                                val status = parsed?.thermalStatus ?: if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                                    powerManager.currentThermalStatus
+                                } else 0
+                                ThermalState(status = status, readStatus = MetricReadStatus.ParseFailed)
+                            }
+                        } else {
+                            consecutiveFailures = 0
+                            val newState = ThermalState(
+                                cpuC = parsed.cpuC ?: 0f,
+                                gpuC = parsed.gpuC ?: 0f,
+                                npuC = parsed.npuC ?: 0f,
+                                skinC = parsed.skinC ?: 0f,
+                                batteryC = parsed.batteryC ?: 0f,
+                                status = parsed.thermalStatus,
+                                readStatus = MetricReadStatus.Ok,
+                                hasCpu = parsed.cpuC != null,
+                                hasGpu = parsed.gpuC != null,
+                                hasNpu = parsed.npuC != null,
+                                hasSkin = parsed.skinC != null,
+                                hasBattery = parsed.batteryC != null
+                            )
+                            lastGoodState = newState
+                            newState
+                        }
+                    }
                 } catch (e: Exception) {
-                    fallbackState(powerManager)
+                    consecutiveFailures++
+                    if (consecutiveFailures <= 3 && lastGoodState != null) {
+                        lastGoodState.copy(readStatus = MetricReadStatus.Stale)
+                    } else {
+                        if (consecutiveFailures > 3) {
+                            lastGoodState = null
+                        }
+                        val status = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                            powerManager.currentThermalStatus
+                        } else 0
+                        ThermalState(status = status, readStatus = MetricReadStatus.ParseFailed)
+                    }
                 }
             } else {
-                fallbackState(powerManager)
+                consecutiveFailures = 0
+                lastGoodState = null
+                val status = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                    powerManager.currentThermalStatus
+                } else 0
+                ThermalState(status = status, readStatus = MetricReadStatus.NoShizuku)
             }
             emit(state)
             delay(1000)
         }
-    }
-
-    private fun parseThermalService(output: String): ThermalState? {
-        if (output.isBlank()) return null
-
-        // Prefer the "Current temperatures from HAL:" section (live values) over
-        // "Cached temperatures:" (may be briefly stale right after a status change).
-        val halSection = output.substringAfter("Current temperatures from HAL:", "")
-            .substringBefore("Current cooling devices")
-        val section = halSection.ifBlank { output }
-
-        var cpu = 0f; var gpu = 0f; var npu = 0f; var skin = 0f; var battery = 0f
-        var found = false
-        entryRegex.findAll(section).forEach { match ->
-            val value = match.groupValues[1].toFloatOrNull() ?: return@forEach
-            val type = match.groupValues[2].toIntOrNull() ?: return@forEach
-            found = true
-            when (type) {
-                0 -> cpu = value
-                1 -> gpu = value
-                2 -> battery = value
-                3 -> skin = value
-                9 -> npu = value
-            }
-        }
-        if (!found) return null
-
-        val status = Regex("Thermal Status:\\s*(\\d+)")
-            .find(output)?.groupValues?.get(1)?.toIntOrNull() ?: 0
-
-        return ThermalState(cpuC = cpu, gpuC = gpu, npuC = npu, skinC = skin, batteryC = battery, status = status)
-    }
-
-    private fun fallbackState(powerManager: PowerManager): ThermalState {
-        val status = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            powerManager.currentThermalStatus
-        } else 0
-        return ThermalState(status = status)
     }
 }
 
@@ -550,44 +570,39 @@ class PingMonitor @Inject constructor(
 class TopProcessMonitor @Inject constructor(
     private val shizukuManager: ShizukuManager
 ) {
-    // Answers "which process was busy at the moment FPS dropped" — a temperature
-    // graph only shows thermal was NOT the cause; this is what actually names the
-    // culprit (a vendor daemon, a sync job, etc.) when a drop isn't thermal.
-    data class TopProcess(val name: String, val cpuPercent: Float)
+    data class TopProcess(
+        val name: String = "",
+        val cpuPercent: Float = 0f,
+        val readStatus: MetricReadStatus = MetricReadStatus.Loading
+    )
 
-    // `dumpsys cpuinfo` header lines look like:
-    //   23% 1234/com.example.app: 15% user + 8% kernel
-    // The leading percentage is that process's share of a single core's capacity,
-    // already sorted busiest-first by the system service — no extra sorting needed.
-    private val lineRegex = Regex("^\\s*([0-9.]+)%\\s+\\d+/([^:]+):")
-
-    val topProcess: Flow<TopProcess?> = flow {
+    val topProcess: Flow<TopProcess> = flow {
         while (true) {
             val shizukuReady = shizukuManager.isShizukuAvailable.value &&
                     shizukuManager.hasPermission.value
 
             val result = if (shizukuReady) {
                 try {
-                    parseTop(shizukuManager.executeCommand("dumpsys cpuinfo"))
+                    val output = shizukuManager.executeCommand("dumpsys cpuinfo")
+                    if (output.isBlank()) {
+                        TopProcess(readStatus = MetricReadStatus.EmptyOutput)
+                    } else {
+                        val parsed = CpuInfoTopParser.parseTop(output)
+                        if (parsed != null) {
+                            TopProcess(name = parsed.name, cpuPercent = parsed.cpuPercent, readStatus = MetricReadStatus.Ok)
+                        } else {
+                            TopProcess(readStatus = MetricReadStatus.NoData)
+                        }
+                    }
                 } catch (e: Exception) {
-                    null
+                    TopProcess(readStatus = MetricReadStatus.ParseFailed)
                 }
-            } else null
+            } else {
+                TopProcess(readStatus = MetricReadStatus.NoShizuku)
+            }
 
             emit(result)
             delay(1000)
         }
-    }
-
-    private fun parseTop(output: String): TopProcess? {
-        for (line in output.lineSequence()) {
-            val match = lineRegex.find(line) ?: continue
-            val pct = match.groupValues[1].toFloatOrNull() ?: continue
-            val name = match.groupValues[2].trim()
-            // Skip the aggregate "TOTAL" line — we want the top real process.
-            if (name.equals("TOTAL", ignoreCase = true)) continue
-            return TopProcess(name, pct)
-        }
-        return null
     }
 }

--- a/app/src/main/java/com/framex/app/metrics/SessionLogger.kt
+++ b/app/src/main/java/com/framex/app/metrics/SessionLogger.kt
@@ -35,7 +35,8 @@ class SessionLogger @Inject constructor(
     // Snapshot index (into metricsEngine.snapshotHistory) marking where this
     // recording session started, so exporting doesn't include earlier history
     // that predates the user pressing "Start".
-    private var recordingStartIndex = 0
+    private var _recordingStartIndex = 0
+    val recordingStartIndex: Int get() = _recordingStartIndex
 
     private val _lastExportedFile = MutableStateFlow<File?>(null)
     val lastExportedFile: StateFlow<File?> = _lastExportedFile.asStateFlow()
@@ -47,7 +48,7 @@ class SessionLogger @Inject constructor(
     private val recordingModules = setOf("thermal", "temp", "cpu", "cpu_cluster", "ram", "top_process")
 
     fun startRecording() {
-        recordingStartIndex = metricsEngine.snapshotHistory.value.size
+        _recordingStartIndex = metricsEngine.snapshotHistory.value.size
         metricsEngine.setScreenOverrideModules(recordingModules, requesterKey = "session_logger")
         _isRecording.value = true
     }
@@ -60,10 +61,10 @@ class SessionLogger @Inject constructor(
     /** Writes the recorded window (start → now) to a CSV in app-private storage
      *  and returns a content:// URI ready to hand to a share Intent. Returns null
      *  if there's nothing to export. */
-    fun exportToFile(): File? {
+    suspend fun exportToFile(): File? = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
         val all = metricsEngine.snapshotHistory.value
-        val window = if (recordingStartIndex in all.indices) all.subList(recordingStartIndex, all.size) else all
-        if (window.isEmpty()) return null
+        val window = if (_recordingStartIndex in all.indices) all.subList(_recordingStartIndex, all.size) else all
+        if (window.isEmpty()) return@withContext null
 
         val dir = File(context.filesDir, "session_logs").apply { mkdirs() }
         val name = "framex_session_${SimpleDateFormat("yyyyMMdd_HHmmss", Locale.US).format(System.currentTimeMillis())}.csv"
@@ -90,7 +91,7 @@ class SessionLogger @Inject constructor(
         }
 
         _lastExportedFile.value = file
-        return file
+        file
     }
 
     /** Builds a share Intent for the given file via FileProvider. Caller starts it
@@ -110,6 +111,6 @@ class SessionLogger @Inject constructor(
     fun currentRecordingCount(): Int {
         if (!_isRecording.value) return 0
         val all = metricsEngine.snapshotHistory.value
-        return (all.size - recordingStartIndex).coerceAtLeast(0)
+        return (all.size - _recordingStartIndex).coerceAtLeast(0)
     }
 }

--- a/app/src/main/java/com/framex/app/metrics/ThermalServiceParser.kt
+++ b/app/src/main/java/com/framex/app/metrics/ThermalServiceParser.kt
@@ -1,0 +1,132 @@
+package com.framex.app.metrics
+
+/**
+ * Pure parser for `dumpsys thermalservice` output.
+ * No Android dependencies — unit-tested with fixture strings.
+ *
+ * Strategy (single pass, O(n) in dump length, O(1) sensor slots):
+ * 1. Prefer the "Current temperatures from HAL:" section when present.
+ * 2. Extract each `Temperature{…}` block; fields may appear in any order.
+ * 3. Classify by mType first (AOSP Temperature types), then by mName keywords.
+ */
+internal object ThermalServiceParser {
+
+    data class Result(
+        val cpuC: Float? = null,
+        val gpuC: Float? = null,
+        val skinC: Float? = null,
+        val npuC: Float? = null,
+        val batteryC: Float? = null,
+        val thermalStatus: Int = 0,
+        /** Number of Temperature{…} blocks that yielded a value. */
+        val entryCount: Int = 0
+    ) {
+        val hasAnySensor: Boolean
+            get() = cpuC != null || gpuC != null || skinC != null || npuC != null || batteryC != null
+    }
+
+    private val blockRegex = Regex("""Temperature\{([^}]*)\}""")
+    private val valueRegex = Regex("""mValue\s*=\s*(-?[0-9.]+)""")
+    private val typeRegex = Regex("""mType\s*=\s*(\d+)""")
+    private val nameRegex = Regex("""mName\s*=\s*([^\s,}]+)""")
+    private val statusRegex = Regex("""Thermal Status:\s*(\d+)""")
+
+    /**
+     * @return parsed sensors, or null when [output] is blank (caller treats as EmptyOutput).
+     *         Non-blank dumps with zero matches return [Result] with [Result.entryCount] == 0
+     *         (caller treats as ParseFailed).
+     */
+    fun parse(output: String): Result? {
+        if (output.isBlank()) return null
+
+        val halSection = output
+            .substringAfter("Current temperatures from HAL:", missingDelimiterValue = "")
+            .substringBefore("Current cooling devices")
+        val section = if (halSection.isNotBlank()) halSection else output
+
+        var cpu: Float? = null
+        var gpu: Float? = null
+        var skin: Float? = null
+        var npu: Float? = null
+        var battery: Float? = null
+        var entryCount = 0
+
+        for (match in blockRegex.findAll(section)) {
+            val body = match.groupValues[1]
+            val value = valueRegex.find(body)?.groupValues?.get(1)?.toFloatOrNull() ?: continue
+            val type = typeRegex.find(body)?.groupValues?.get(1)?.toIntOrNull()
+            val name = nameRegex.find(body)?.groupValues?.get(1).orEmpty()
+
+            when (classify(type, name)) {
+                SensorKind.CPU -> {
+                    cpu = value
+                    entryCount++
+                }
+                SensorKind.GPU -> {
+                    gpu = value
+                    entryCount++
+                }
+                SensorKind.SKIN -> {
+                    skin = value
+                    entryCount++
+                }
+                SensorKind.NPU -> {
+                    npu = value
+                    entryCount++
+                }
+                SensorKind.BATTERY -> {
+                    battery = value
+                    entryCount++
+                }
+                SensorKind.UNKNOWN -> {
+                    // Count unknown Temperature blocks so ParseFailed is not falsely reported
+                    // when the HAL only exposes types we do not map (still entryCount may be 0
+                    // for mapping purposes — we only increment mapped sensors above).
+                    // If nothing maps at all, entryCount stays 0 → ParseFailed at caller.
+                }
+            }
+        }
+
+        val thermalStatus = statusRegex.find(output)
+            ?.groupValues?.get(1)
+            ?.toIntOrNull()
+            ?: 0
+
+        return Result(
+            cpuC = cpu,
+            gpuC = gpu,
+            skinC = skin,
+            npuC = npu,
+            batteryC = battery,
+            thermalStatus = thermalStatus,
+            entryCount = entryCount
+        )
+    }
+
+    private enum class SensorKind { CPU, GPU, SKIN, NPU, BATTERY, UNKNOWN }
+
+    /**
+     * AOSP Temperature types: 0=CPU 1=GPU 2=BATTERY 3=SKIN 9=NPU.
+     * Name fallback is case-insensitive and matches common OEM labels.
+     */
+    private fun classify(type: Int?, name: String): SensorKind {
+        when (type) {
+            0 -> return SensorKind.CPU
+            1 -> return SensorKind.GPU
+            2 -> return SensorKind.BATTERY
+            3 -> return SensorKind.SKIN
+            9 -> return SensorKind.NPU
+        }
+
+        val n = name.uppercase()
+        return when {
+            n.contains("SKIN") -> SensorKind.SKIN
+            n.contains("GPU") || n.contains("GRAPHICS") -> SensorKind.GPU
+            n.contains("NPU") || n.contains("TPU") || n.contains("APU") -> SensorKind.NPU
+            n.contains("BATTERY") || n.contains("BATT") -> SensorKind.BATTERY
+            // CPU last: many labels include "CPU" as a substring of longer names
+            n.contains("CPU") || n.contains("SOC") || n.contains("CLUSTER") -> SensorKind.CPU
+            else -> SensorKind.UNKNOWN
+        }
+    }
+}

--- a/app/src/main/java/com/framex/app/ui/screens/ThermalDiagnosticsScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/ThermalDiagnosticsScreen.kt
@@ -1,7 +1,9 @@
 package com.framex.app.ui.screens
 
 import android.content.Intent
+import android.os.Build
 import android.widget.Toast
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -23,17 +25,21 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.StrokeCap
-import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalLifecycleOwner
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.framex.app.metrics.MetricReadStatus
 import com.framex.app.metrics.MetricsEngine
 import com.framex.app.metrics.MetricsState
 import com.framex.app.metrics.SessionLogger
+import com.framex.app.shizuku.ShizukuManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.stateIn
@@ -47,7 +53,8 @@ import javax.inject.Inject
 @HiltViewModel
 class ThermalDiagnosticsViewModel @Inject constructor(
     private val metricsEngine: MetricsEngine,
-    private val sessionLogger: SessionLogger
+    private val sessionLogger: SessionLogger,
+    private val shizukuManager: ShizukuManager
 ) : ViewModel() {
 
     val metricsState = metricsEngine.metricsState
@@ -59,12 +66,20 @@ class ThermalDiagnosticsViewModel @Inject constructor(
     val isRecording = sessionLogger.isRecording
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
 
+    val isShizukuAvailable = shizukuManager.isShizukuAvailable
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
+    val hasShizukuPermission = shizukuManager.hasPermission
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), false)
+
     init {
-        // Force "thermal" and "temp" on for this screen — "temp" (battery) previously
-        // wasn't forced here, so BATTERY read 0 unless the user separately had it
-        // toggled on their overlay. Uses a distinct requester key so it can't collide
+        // Force "thermal", "temp", and "top_process" on for this screen.
+        // Uses a distinct requester key so it can't collide
         // with SessionLogger's own override when a recording is also active.
-        metricsEngine.setScreenOverrideModules(setOf("thermal", "temp"), requesterKey = "thermal_diagnostics_screen")
+        metricsEngine.setScreenOverrideModules(
+            setOf("thermal", "temp", "top_process"),
+            requesterKey = "thermal_diagnostics_screen"
+        )
     }
 
     override fun onCleared() {
@@ -80,7 +95,18 @@ class ThermalDiagnosticsViewModel @Inject constructor(
         }
     }
 
-    fun recordedSampleCount(): Int = sessionLogger.currentRecordingCount()
+    fun recordedSampleCount(snapshots: List<MetricsEngine.MetricsSnapshot>): Int {
+        val startIndex = sessionLogger.recordingStartIndex
+        return (snapshots.size - startIndex).coerceAtLeast(0)
+    }
+
+    fun requestShizukuPermission() {
+        shizukuManager.requestPermission()
+    }
+
+    fun refreshShizukuState() {
+        shizukuManager.refreshState()
+    }
 
     fun exportAndShare(onReady: (Intent) -> Unit, onEmpty: () -> Unit) {
         viewModelScope.launch {
@@ -105,9 +131,47 @@ private fun thermalStatusLabel(status: Int): String = when (status) {
 
 private fun thermalStatusColor(status: Int): Color = when {
     status <= 1 -> Color(0xFF34D399) // green — none/light
-    status == 2 -> Color(0xFFFBBF24) // amber — moderate (this is what tripped at your 40.6°C skin reading)
+    status == 2 -> Color(0xFFFBBF24) // amber — moderate
     status == 3 -> Color(0xFFF97316) // orange — severe
     else -> Color(0xFFEF4444)        // red — critical and above
+}
+
+private fun getThermalDisplayValue(value: Float, present: Boolean, readStatus: MetricReadStatus): String {
+    return when (readStatus) {
+        MetricReadStatus.NoShizuku -> "Needs Shizuku"
+        MetricReadStatus.EmptyOutput -> "Unavailable"
+        MetricReadStatus.ParseFailed -> "Parse Failed"
+        MetricReadStatus.Loading -> "Waiting..."
+        else -> {
+            if (present) {
+                String.format(java.util.Locale.US, "%.1f°C", value)
+            } else {
+                "Unavailable"
+            }
+        }
+    }
+}
+
+private fun getBatteryDisplayValue(tempC: Float): String {
+    return if (tempC <= 0f) "Unavailable" else String.format(java.util.Locale.US, "%.1f°C", tempC)
+}
+
+private fun getTopProcessDisplayValue(name: String?, percent: Float, readStatus: MetricReadStatus): String {
+    return when (readStatus) {
+        MetricReadStatus.NoShizuku -> "Needs Shizuku"
+        MetricReadStatus.EmptyOutput -> "Unavailable"
+        MetricReadStatus.ParseFailed -> "Parse Failed"
+        MetricReadStatus.Loading -> "Waiting..."
+        MetricReadStatus.NoData -> "No process data"
+        MetricReadStatus.Ok -> {
+            if (name != null) {
+                "$name (${String.format(java.util.Locale.US, "%.0f", percent)}%)"
+            } else {
+                "—"
+            }
+        }
+        else -> "—"
+    }
 }
 
 @Composable
@@ -118,8 +182,21 @@ fun ThermalDiagnosticsScreen(
     val metricsState by viewModel.metricsState.collectAsState()
     val snapshotHistory by viewModel.snapshotHistory.collectAsState()
     val isRecording by viewModel.isRecording.collectAsState()
+    val isShizukuAvailable by viewModel.isShizukuAvailable.collectAsState()
+    val hasShizukuPermission by viewModel.hasShizukuPermission.collectAsState()
     val context = LocalContext.current
-    val scope = rememberCoroutineScope()
+
+    // Re-check Shizuku state on resume
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            if (event == Lifecycle.Event.ON_RESUME) {
+                viewModel.refreshShizukuState()
+            }
+        }
+        lifecycleOwner.lifecycle.addObserver(observer)
+        onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
+    }
 
     // Last 60 snapshots (~60s at 1s cadence) drive the correlation graph — same
     // window size as the Dashboard's FPS sparkline, so the two feel consistent.
@@ -147,6 +224,64 @@ fun ThermalDiagnosticsScreen(
                     .padding(horizontal = 24.dp)
                     .verticalScroll(rememberScrollState()),
             ) {
+                // Shizuku CTA Banner
+                if (!isShizukuAvailable || !hasShizukuPermission) {
+                    Card(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = 16.dp),
+                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.errorContainer.copy(alpha = 0.15f)),
+                        border = BorderStroke(1.dp, MaterialTheme.colorScheme.error.copy(alpha = 0.3f)),
+                        shape = RoundedCornerShape(12.dp)
+                    ) {
+                        Column(modifier = Modifier.padding(16.dp)) {
+                            Text(
+                                text = if (!isShizukuAvailable) "Shizuku Service Not Running" else "Shizuku Authorization Required",
+                                color = MaterialTheme.colorScheme.error,
+                                fontWeight = FontWeight.Bold,
+                                style = MaterialTheme.typography.titleMedium
+                            )
+                            Spacer(modifier = Modifier.height(4.dp))
+                            Text(
+                                text = if (!isShizukuAvailable) {
+                                    "Start Shizuku via wireless debugging or adb to view active CPU/GPU thermal sensors and top processes."
+                                } else {
+                                    "Authorize FrameX in the Shizuku app to read system thermal stats and CPU dumps."
+                                },
+                                color = Color.LightGray,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                                Button(
+                                    onClick = {
+                                        val intent = context.packageManager.getLaunchIntentForPackage("moe.shizuku.privileged.api")
+                                        if (intent != null) {
+                                            context.startActivity(intent)
+                                        } else {
+                                            Toast.makeText(context, "Shizuku app not found", Toast.LENGTH_SHORT).show()
+                                        }
+                                    },
+                                    colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error.copy(alpha = 0.2f), contentColor = Color.White),
+                                    modifier = Modifier.height(36.dp),
+                                    shape = CircleShape
+                                ) {
+                                    Text("Open Shizuku", fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                                }
+                                if (isShizukuAvailable && !hasShizukuPermission) {
+                                    Button(
+                                        onClick = { viewModel.requestShizukuPermission() },
+                                        modifier = Modifier.height(36.dp),
+                                        shape = CircleShape
+                                    ) {
+                                        Text("Grant Permission", fontSize = 12.sp, fontWeight = FontWeight.Bold)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
                 // Current status banner — the single most useful glance value.
                 val status = metricsState.thermalStatus
                 Row(
@@ -166,9 +301,18 @@ fun ThermalDiagnosticsScreen(
                             color = Color.White,
                             fontWeight = FontWeight.Bold
                         )
+                        val statusText = when (status) {
+                            0 -> "NONE — no elevated thermal status reported"
+                            1 -> "LIGHT — slight temperature increase"
+                            2 -> "MODERATE — performance may be slightly throttled"
+                            3 -> "SEVERE — throttling is active to reduce heat"
+                            4 -> "CRITICAL — severe throttling active"
+                            5 -> "EMERGENCY — critical safety limits reached"
+                            6 -> "SHUTDOWN — device shutting down due to heat"
+                            else -> "UNKNOWN thermal status"
+                        }
                         Text(
-                            if (status >= 2) "Android is actively throttling performance right now"
-                            else "No throttling active",
+                            statusText,
                             color = Color.Gray,
                             style = MaterialTheme.typography.bodySmall
                         )
@@ -179,25 +323,30 @@ fun ThermalDiagnosticsScreen(
 
                 // Readings grid
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    ReadingCard("CPU", String.format("%.1f°C", metricsState.thermalCpuC), Modifier.weight(1f))
-                    ReadingCard("GPU", String.format("%.1f°C", metricsState.thermalGpuC), Modifier.weight(1f))
+                    ReadingCard("CPU", getThermalDisplayValue(metricsState.thermalCpuC, metricsState.hasThermalCpu, metricsState.thermalReadStatus), Modifier.weight(1f))
+                    ReadingCard("GPU", getThermalDisplayValue(metricsState.thermalGpuC, metricsState.hasThermalGpu, metricsState.thermalReadStatus), Modifier.weight(1f))
                 }
                 Spacer(modifier = Modifier.height(12.dp))
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
-                    ReadingCard("SKIN", String.format("%.1f°C", metricsState.thermalSkinC), Modifier.weight(1f))
-                    ReadingCard("BATTERY", String.format("%.1f°C", metricsState.batteryTempC), Modifier.weight(1f))
+                    ReadingCard("SKIN", getThermalDisplayValue(metricsState.thermalSkinC, metricsState.hasThermalSkin, metricsState.thermalReadStatus), Modifier.weight(1f))
+                    ReadingCard("NPU", getThermalDisplayValue(metricsState.thermalNpuC, metricsState.hasThermalNpu, metricsState.thermalReadStatus), Modifier.weight(1f))
                 }
                 Spacer(modifier = Modifier.height(12.dp))
                 Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                    ReadingCard("BATTERY", getBatteryDisplayValue(metricsState.batteryTempC), Modifier.weight(1f))
                     ReadingCard("JANKY FRAMES", "${metricsState.jankyFrames}", Modifier.weight(1f))
+                }
+                Spacer(modifier = Modifier.height(12.dp))
+                Row(modifier = Modifier.fillMaxWidth()) {
                     ReadingCard(
                         "TOP PROCESS",
-                        metricsState.topProcessName?.let { "$it (${String.format("%.0f", metricsState.topProcessCpuPercent)}%)" } ?: "—",
-                        Modifier.weight(1f)
+                        getTopProcessDisplayValue(metricsState.topProcessName, metricsState.topProcessCpuPercent, metricsState.topProcessReadStatus),
+                        Modifier.fillMaxWidth()
                     )
                 }
 
                 Spacer(modifier = Modifier.height(24.dp))
+
                 Text("FPS vs Thermal — last 60s", style = MaterialTheme.typography.titleSmall, color = Color.White)
                 Text(
                     "Look for the moment FPS drops and check what moved at the same second below.",
@@ -234,8 +383,8 @@ fun ThermalDiagnosticsScreen(
                 )
                 Spacer(modifier = Modifier.height(16.dp))
 
+                val count = viewModel.recordedSampleCount(snapshotHistory)
                 if (isRecording) {
-                    val count = viewModel.recordedSampleCount()
                     Row(
                         modifier = Modifier
                             .fillMaxWidth()
@@ -247,6 +396,20 @@ fun ThermalDiagnosticsScreen(
                         Icon(Icons.Default.FiberManualRecord, contentDescription = null, tint = Color(0xFFEF4444), modifier = Modifier.size(12.dp))
                         Spacer(modifier = Modifier.width(8.dp))
                         Text("Recording — ${count}s captured", color = Color.White, fontWeight = FontWeight.Bold)
+                    }
+                    Spacer(modifier = Modifier.height(12.dp))
+                } else if (count > 0) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(12.dp))
+                            .background(Color(0xFF34D399).copy(alpha = 0.1f))
+                            .padding(12.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Icon(Icons.Default.FiberManualRecord, contentDescription = null, tint = Color(0xFF34D399), modifier = Modifier.size(12.dp))
+                        Spacer(modifier = Modifier.width(8.dp))
+                        Text("Last Session — ${count}s ready to export", color = Color.White, fontWeight = FontWeight.Bold)
                     }
                     Spacer(modifier = Modifier.height(12.dp))
                 }
@@ -322,37 +485,64 @@ private fun CorrelationGraph(
     snapshots: List<MetricsEngine.MetricsSnapshot>,
     modifier: Modifier = Modifier
 ) {
-    Canvas(modifier = modifier) {
-        if (snapshots.size < 2) return@Canvas
+    Box(modifier = modifier, contentAlignment = Alignment.Center) {
+        if (snapshots.size < 2) {
+            Text("Collecting samples...", color = Color.Gray, style = MaterialTheme.typography.bodyMedium)
+        } else {
+            val hasCpu = snapshots.any { it.state.hasThermalCpu }
+            val hasSkin = snapshots.any { it.state.hasThermalSkin }
 
-        val maxFps = (snapshots.maxOfOrNull { it.state.fps } ?: 1).coerceAtLeast(1)
-        val maxTemp = (snapshots.maxOfOrNull { maxOf(it.state.thermalCpuC, it.state.thermalSkinC) } ?: 1f).coerceAtLeast(1f)
+            Canvas(modifier = Modifier.fillMaxSize()) {
+                val maxFps = (snapshots.maxOfOrNull { it.state.fps } ?: 1).coerceAtLeast(1)
+                
+                // Only count valid thermal readings when finding max temperature
+                val cpuTemps = if (hasCpu) snapshots.map { it.state.thermalCpuC } else emptyList()
+                val skinTemps = if (hasSkin) snapshots.map { it.state.thermalSkinC } else emptyList()
+                
+                val maxTemp = (cpuTemps + skinTemps).maxOrNull()?.coerceAtLeast(1f) ?: 100f
 
-        val stepX = size.width / (snapshots.size - 1).coerceAtLeast(1)
+                val stepX = size.width / (snapshots.size - 1).coerceAtLeast(1)
 
-        fun pointsFor(values: List<Float>, max: Float): List<Offset> =
-            values.mapIndexed { i, v ->
-                Offset(i * stepX, size.height - (v / max) * size.height)
+                fun pointsFor(values: List<Float>, max: Float): List<Offset> =
+                    values.mapIndexed { i, v ->
+                        Offset(i * stepX, size.height - (v / max) * size.height)
+                    }
+
+                val fpsPoints = pointsFor(snapshots.map { it.state.fps.toFloat() }, maxFps.toFloat())
+                
+                fun drawLine(points: List<Offset>, color: Color) {
+                    for (i in 0 until points.size - 1) {
+                        drawLine(
+                            color = color,
+                            start = points[i],
+                            end = points[i + 1],
+                            strokeWidth = 3f,
+                            cap = StrokeCap.Round
+                        )
+                    }
+                }
+
+                if (hasCpu) {
+                    val cpuPoints = pointsFor(cpuTemps, maxTemp)
+                    drawLine(cpuPoints, Color(0xFFEF4444).copy(alpha = 0.8f))
+                }
+                if (hasSkin) {
+                    val skinPoints = pointsFor(skinTemps, maxTemp)
+                    drawLine(skinPoints, Color(0xFFFBBF24).copy(alpha = 0.8f))
+                }
+                drawLine(fpsPoints, Color(0xFF60A5FA))
             }
-
-        val fpsPoints = pointsFor(snapshots.map { it.state.fps.toFloat() }, maxFps.toFloat())
-        val cpuPoints = pointsFor(snapshots.map { it.state.thermalCpuC }, maxTemp)
-        val skinPoints = pointsFor(snapshots.map { it.state.thermalSkinC }, maxTemp)
-
-        fun drawLine(points: List<Offset>, color: Color) {
-            for (i in 0 until points.size - 1) {
-                drawLine(
-                    color = color,
-                    start = points[i],
-                    end = points[i + 1],
-                    strokeWidth = 3f,
-                    cap = StrokeCap.Round
-                )
+            
+            if (!hasCpu && !hasSkin) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(Color.Black.copy(alpha = 0.3f)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("Thermal series unavailable", color = Color.Gray, style = MaterialTheme.typography.bodyMedium)
+                }
             }
         }
-
-        drawLine(cpuPoints, Color(0xFFEF4444).copy(alpha = 0.8f))
-        drawLine(skinPoints, Color(0xFFFBBF24).copy(alpha = 0.8f))
-        drawLine(fpsPoints, Color(0xFF60A5FA))
     }
 }

--- a/app/src/test/java/com/framex/app/metrics/CpuInfoTopParserTest.kt
+++ b/app/src/test/java/com/framex/app/metrics/CpuInfoTopParserTest.kt
@@ -1,0 +1,47 @@
+package com.framex.app.metrics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CpuInfoTopParserTest {
+
+    @Test
+    fun blankReturnsNull() {
+        assertNull(CpuInfoTopParser.parseTop(""))
+        assertNull(CpuInfoTopParser.parseTop("   "))
+    }
+
+    @Test
+    fun parsesBusiestProcessLine() {
+        val dump = """
+            Load: 4.2 / 3.1 / 2.0
+            CPU usage from 1000ms to 0ms ago (2020-01-01 00:00:00.000 to 2020-01-01 00:00:01.000):
+              23% 1234/com.example.game: 15% user + 8% kernel / faults: 10 minor 0 major
+              12% 56/system_server: 10% user + 2% kernel
+              5.5% 789/com.android.systemui: 4% user + 1.5% kernel
+            +0% TOTAL: ...
+        """.trimIndent()
+
+        val top = CpuInfoTopParser.parseTop(dump)!!
+        assertEquals("com.example.game", top.name)
+        assertEquals(23f, top.cpuPercent, 0.01f)
+    }
+
+    @Test
+    fun skipsTotalLineIfFirst() {
+        val dump = """
+              100% 0/TOTAL: 50% user + 50% kernel
+              18% 42/com.android.chrome: 10% user + 8% kernel
+        """.trimIndent()
+
+        val top = CpuInfoTopParser.parseTop(dump)!!
+        assertEquals("com.android.chrome", top.name)
+        assertEquals(18f, top.cpuPercent, 0.01f)
+    }
+
+    @Test
+    fun noMatchingLinesReturnsNull() {
+        assertNull(CpuInfoTopParser.parseTop("Load: 1.0\nno process lines"))
+    }
+}

--- a/app/src/test/java/com/framex/app/metrics/ThermalServiceParserTest.kt
+++ b/app/src/test/java/com/framex/app/metrics/ThermalServiceParserTest.kt
@@ -1,0 +1,114 @@
+package com.framex.app.metrics
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ThermalServiceParserTest {
+
+    @Test
+    fun blankOutputReturnsNull() {
+        assertNull(ThermalServiceParser.parse(""))
+        assertNull(ThermalServiceParser.parse("   \n"))
+    }
+
+    @Test
+    fun parsesCanonicalAospHalBlock() {
+        val dump = """
+            IsStatusOverride: false
+            Thermal Status: 2
+            Cached temperatures:
+            Current temperatures from HAL:
+            Temperature{mValue=62.895, mType=0, mName=CPU, mStatus=0}
+            Temperature{mValue=55.1, mType=1, mName=GPU, mStatus=0}
+            Temperature{mValue=40.6, mType=3, mName=SKIN, mStatus=2}
+            Temperature{mValue=33.0, mType=2, mName=BATTERY, mStatus=0}
+            Temperature{mValue=48.2, mType=9, mName=NPU, mStatus=0}
+            Current cooling devices from HAL:
+            CoolingDevice{mValue=1, mType=0, mName=thermal-cpufreq}
+        """.trimIndent()
+
+        val result = ThermalServiceParser.parse(dump)
+        assertNotNull(result)
+        assertEquals(62.895f, result!!.cpuC!!, 0.001f)
+        assertEquals(55.1f, result.gpuC!!, 0.001f)
+        assertEquals(40.6f, result.skinC!!, 0.001f)
+        assertEquals(33.0f, result.batteryC!!, 0.001f)
+        assertEquals(48.2f, result.npuC!!, 0.001f)
+        assertEquals(2, result.thermalStatus)
+        assertEquals(5, result.entryCount)
+        assertTrue(result.hasAnySensor)
+    }
+
+    @Test
+    fun toleratesReorderedFields() {
+        val dump = """
+            Thermal Status: 0
+            Current temperatures from HAL:
+            Temperature{mName=CPU, mStatus=0, mType=0, mValue=51.25}
+            Temperature{mType=1, mValue=44.0, mName=GPU, mStatus=0}
+            Current cooling devices from HAL:
+        """.trimIndent()
+
+        val result = ThermalServiceParser.parse(dump)!!
+        assertEquals(51.25f, result.cpuC!!, 0.001f)
+        assertEquals(44.0f, result.gpuC!!, 0.001f)
+        assertEquals(2, result.entryCount)
+    }
+
+    @Test
+    fun classifiesByNameWhenTypeUnknown() {
+        val dump = """
+            Thermal Status: 1
+            Current temperatures from HAL:
+            Temperature{mValue=50.0, mType=99, mName=big-CPU-cluster, mStatus=0}
+            Temperature{mValue=41.0, mType=99, mName=skin0, mStatus=0}
+            Temperature{mValue=39.0, mType=99, mName=gpu_therm, mStatus=0}
+            Current cooling devices from HAL:
+        """.trimIndent()
+
+        val result = ThermalServiceParser.parse(dump)!!
+        assertEquals(50.0f, result.cpuC!!, 0.001f)
+        assertEquals(41.0f, result.skinC!!, 0.001f)
+        assertEquals(39.0f, result.gpuC!!, 0.001f)
+        assertEquals(1, result.thermalStatus)
+    }
+
+    @Test
+    fun fallsBackToFullDumpWhenHalSectionMissing() {
+        val dump = """
+            Thermal Status: 0
+            Temperature{mValue=47.0, mType=0, mName=CPU, mStatus=0}
+            Temperature{mValue=38.0, mType=3, mName=SKIN, mStatus=0}
+        """.trimIndent()
+
+        val result = ThermalServiceParser.parse(dump)!!
+        assertEquals(47.0f, result.cpuC!!, 0.001f)
+        assertEquals(38.0f, result.skinC!!, 0.001f)
+        assertTrue(result.hasAnySensor)
+    }
+
+    @Test
+    fun garbageNonBlankYieldsZeroEntries() {
+        val result = ThermalServiceParser.parse("hello world\nno temperatures here")
+        assertNotNull(result)
+        assertEquals(0, result!!.entryCount)
+        assertFalse(result.hasAnySensor)
+        assertNull(result.cpuC)
+    }
+
+    @Test
+    fun spacesAroundEqualsAreAccepted() {
+        val dump = """
+            Thermal Status: 3
+            Temperature{mValue = 60.0, mType = 0, mName = CPU, mStatus = 0}
+        """.trimIndent()
+
+        val result = ThermalServiceParser.parse(dump)!!
+        assertEquals(60.0f, result.cpuC!!, 0.001f)
+        assertEquals(3, result.thermalStatus)
+    }
+}


### PR DESCRIPTION
fix(metrics): fix thermal diagnostics readings and live top process

Improve Thermal Diagnostics screen reliability by fixing sensor fallbacks 
and decoupling the top process monitor so it runs dynamically without 
requiring an active recording session.

- Introduce dedicated diagnostic states to cleanly differentiate between live zeros, loading states, missing Shizuku permissions, or parsing failures.
- Robustly overhaul the telemetry pipeline to parse the HAL thermal service dump directly, preventing unexpected dropouts by holding the last known good state.
- Add a Shizuku authorization CTA banner, dedicated monitoring for NPU hardware temperatures, and graceful UI graph fallbacks when data goes stale.
- Implement comprehensive unit test coverage for both HAL temperature and top process parser logic.

Fixes #15