### PR TITLE
feat(overlay): add continuous overlay scale slider with preset sync (#30)

### DIFF
--- a/app/src/main/java/com/framex/app/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/framex/app/overlay/OverlayManager.kt
@@ -74,6 +74,7 @@ class OverlayManager @Inject constructor(
                     val moduleOrder by settingsRepository.moduleOrder.collectAsState()
                     val opacity by settingsRepository.overlayOpacity.collectAsState()
                     val textSize by settingsRepository.overlayTextSize.collectAsState()
+                    val overlayScale by settingsRepository.overlayScale.collectAsState()
                     val useMonospace by settingsRepository.overlayUseMonospace.collectAsState()
                     val colorIndex by settingsRepository.overlayColorIndex.collectAsState()
                     val bgColorIndex by settingsRepository.overlayBgColorIndex.collectAsState()
@@ -87,6 +88,7 @@ class OverlayManager @Inject constructor(
                         moduleOrder = moduleOrder,
                         opacity = opacity,
                         textSize = textSize,
+                        overlayScale = overlayScale,
                         useMonospace = useMonospace,
                         colorIndex = colorIndex,
                         bgColorIndex = bgColorIndex,
@@ -276,7 +278,8 @@ fun OverlayContent(
     enabledModules: Set<String>,
     moduleOrder: List<String>,
     opacity: Float,
-    textSize: Int,
+    textSize: Int = 1,
+    overlayScale: Float = 1.0f,
     useMonospace: Boolean,
     colorIndex: Int,
     bgColorIndex: Int = 0,
@@ -293,6 +296,7 @@ fun OverlayContent(
         moduleOrder = moduleOrder,
         opacity = opacity,
         textSize = textSize,
+        overlayScale = overlayScale,
         useMonospace = useMonospace,
         colorIndex = colorIndex,
         bgColorIndex = bgColorIndex,

--- a/app/src/main/java/com/framex/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/framex/app/repository/SettingsRepository.kt
@@ -45,6 +45,19 @@ class SettingsRepository @Inject constructor(
     private val _overlayTextSize = MutableStateFlow(prefs.getInt(KEY_OVERLAY_TEXT_SIZE, 1))
     val overlayTextSize: StateFlow<Int> = _overlayTextSize.asStateFlow()
 
+    private val _overlayScale = MutableStateFlow(
+        if (prefs.contains(KEY_OVERLAY_SCALE)) {
+            prefs.getFloat(KEY_OVERLAY_SCALE, 1.0f)
+        } else {
+            when (prefs.getInt(KEY_OVERLAY_TEXT_SIZE, 1)) {
+                0 -> 0.8f
+                2 -> 1.2f
+                else -> 1.0f
+            }
+        }
+    )
+    val overlayScale: StateFlow<Float> = _overlayScale.asStateFlow()
+
     private val _overlayUseMonospace = MutableStateFlow(prefs.getBoolean(KEY_OVERLAY_USE_MONOSPACE, false))
     val overlayUseMonospace: StateFlow<Boolean> = _overlayUseMonospace.asStateFlow()
 
@@ -94,8 +107,27 @@ class SettingsRepository @Inject constructor(
     }
 
     fun setOverlayTextSize(size: Int) {
-        prefs.edit().putInt(KEY_OVERLAY_TEXT_SIZE, size).apply()
-        _overlayTextSize.value = size
+        val targetScale = when (size) {
+            0 -> 0.8f
+            2 -> 1.2f
+            else -> 1.0f
+        }
+        setOverlayScale(targetScale)
+    }
+
+    fun setOverlayScale(scale: Float) {
+        prefs.edit().putFloat(KEY_OVERLAY_SCALE, scale).apply()
+        _overlayScale.value = scale
+        val matchedIndex = when {
+            kotlin.math.abs(scale - 0.8f) < 0.05f -> 0
+            kotlin.math.abs(scale - 1.0f) < 0.05f -> 1
+            kotlin.math.abs(scale - 1.2f) < 0.05f -> 2
+            else -> -1
+        }
+        if (matchedIndex != -1) {
+            prefs.edit().putInt(KEY_OVERLAY_TEXT_SIZE, matchedIndex).apply()
+            _overlayTextSize.value = matchedIndex
+        }
     }
 
     fun setOverlayUseMonospace(useMonospace: Boolean) {
@@ -282,6 +314,7 @@ class SettingsRepository @Inject constructor(
         private const val MODULE_ORDER_DELIMITER = ","
         private const val KEY_OVERLAY_OPACITY = "overlay_opacity"
         private const val KEY_OVERLAY_TEXT_SIZE = "overlay_text_size"
+        private const val KEY_OVERLAY_SCALE = "overlay_scale"
         private const val KEY_OVERLAY_USE_MONOSPACE = "overlay_use_monospace"
         private const val KEY_OVERLAY_COLOR_INDEX = "overlay_color_index"
         private const val KEY_OVERLAY_BG_COLOR_INDEX = "overlay_bg_color_index"

--- a/app/src/main/java/com/framex/app/ui/components/OverlayPreviewContent.kt
+++ b/app/src/main/java/com/framex/app/ui/components/OverlayPreviewContent.kt
@@ -27,7 +27,8 @@ fun OverlayPreviewContent(
     enabledModules: Set<String>,
     moduleOrder: List<String>,
     opacity: Float,
-    textSize: Int,
+    textSize: Int = 1,
+    overlayScale: Float = 1.0f,
     useMonospace: Boolean,
     colorIndex: Int,
     bgColorIndex: Int = 0,
@@ -58,7 +59,7 @@ fun OverlayPreviewContent(
     )
     val accentColor = colors.getOrElse(colorIndex) { MaterialTheme.colorScheme.primary }
     val fontFamily = if (useMonospace) FontFamily.Monospace else MaterialTheme.typography.bodyMedium.fontFamily
-    val textScale = when (textSize) { 0 -> 0.8f; 2 -> 1.2f; else -> 1.0f }
+    val textScale = if (overlayScale != 1.0f || textSize == 1) overlayScale else when (textSize) { 0 -> 0.8f; 2 -> 1.2f; else -> 1.0f }
 
     val bgColors = listOf(Color.Black, Color(0xFF0D1117), Color(0xFF1C1C1E), Color.Transparent)
     val bgBase = bgColors.getOrElse(bgColorIndex) { Color.Black }

--- a/app/src/main/java/com/framex/app/ui/screens/AppearanceScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/AppearanceScreen.kt
@@ -38,6 +38,7 @@ class AppearanceViewModel @Inject constructor(
     val moduleOrder = settingsRepository.moduleOrder
     val overlayOpacity = settingsRepository.overlayOpacity
     val overlayTextSize = settingsRepository.overlayTextSize
+    val overlayScale = settingsRepository.overlayScale
     val overlayUseMonospace = settingsRepository.overlayUseMonospace
     val overlayColorIndex = settingsRepository.overlayColorIndex
     val overlayBgColorIndex = settingsRepository.overlayBgColorIndex
@@ -45,11 +46,11 @@ class AppearanceViewModel @Inject constructor(
     val overlayTextColorIndex = settingsRepository.overlayTextColorIndex
 
     fun saveSettings(
-        opacity: Float, textSize: Int, useMonospace: Boolean, colorIndex: Int,
+        opacity: Float, scale: Float, useMonospace: Boolean, colorIndex: Int,
         bgColorIndex: Int, borderColorIndex: Int, textColorIndex: Int
     ) {
         settingsRepository.setOverlayOpacity(opacity)
-        settingsRepository.setOverlayTextSize(textSize)
+        settingsRepository.setOverlayScale(scale)
         settingsRepository.setOverlayUseMonospace(useMonospace)
         settingsRepository.setOverlayColorIndex(colorIndex)
         settingsRepository.setOverlayBgColorIndex(bgColorIndex)
@@ -65,6 +66,7 @@ fun AppearanceScreen(
 ) {
     val savedOpacity by viewModel.overlayOpacity.collectAsState()
     val savedTextSize by viewModel.overlayTextSize.collectAsState()
+    val savedScale by viewModel.overlayScale.collectAsState()
     val savedUseMonospace by viewModel.overlayUseMonospace.collectAsState()
     val savedColorIndex by viewModel.overlayColorIndex.collectAsState()
     val savedBgColorIndex by viewModel.overlayBgColorIndex.collectAsState()
@@ -78,6 +80,7 @@ fun AppearanceScreen(
 
     var opacity by remember(savedOpacity) { mutableStateOf(savedOpacity) }
     var selectedTextSize by remember(savedTextSize) { mutableStateOf(savedTextSize) }
+    var overlayScale by remember(savedScale) { mutableStateOf(savedScale) }
     var useMonospace by remember(savedUseMonospace) { mutableStateOf(savedUseMonospace) }
     var selectedColorIndex by remember(savedColorIndex) { mutableStateOf(savedColorIndex) }
     var selectedBgColorIndex by remember(savedBgColorIndex) { mutableStateOf(savedBgColorIndex) }
@@ -85,6 +88,7 @@ fun AppearanceScreen(
     var selectedTextColorIndex by remember(savedTextColorIndex) { mutableStateOf(savedTextColorIndex) }
     
     val hasChanges = opacity != savedOpacity || selectedTextSize != savedTextSize ||
+        kotlin.math.abs(overlayScale - savedScale) > 0.01f ||
         useMonospace != savedUseMonospace || selectedColorIndex != savedColorIndex ||
         selectedBgColorIndex != savedBgColorIndex || selectedBorderColorIndex != savedBorderColorIndex ||
         selectedTextColorIndex != savedTextColorIndex
@@ -145,6 +149,7 @@ fun AppearanceScreen(
                             moduleOrder = moduleOrder,
                             opacity = opacity,
                             textSize = selectedTextSize,
+                            overlayScale = overlayScale,
                             useMonospace = useMonospace,
                             colorIndex = selectedColorIndex,
                             bgColorIndex = selectedBgColorIndex,
@@ -264,7 +269,14 @@ fun AppearanceScreen(
                 ) {
                     Column {
                         Column(modifier = Modifier.padding(20.dp)) {
-                            Text("Text Size", color = Color.White, fontWeight = FontWeight.Medium)
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                Text("Text Size & Scale", color = Color.White, fontWeight = FontWeight.Medium)
+                                Text("${(overlayScale * 100).toInt()}%", color = colors[selectedColorIndex], fontWeight = FontWeight.Bold)
+                            }
                             Spacer(modifier = Modifier.height(16.dp))
                             Row(
                                 modifier = Modifier
@@ -274,24 +286,51 @@ fun AppearanceScreen(
                                     .padding(4.dp)
                             ) {
                                 listOf("Small", "Medium", "Large").forEachIndexed { index, label ->
+                                    val isSelected = selectedTextSize == index
                                     Box(
                                         modifier = Modifier
                                             .weight(1f)
                                             .clip(RoundedCornerShape(8.dp))
-                                            .background(if (selectedTextSize == index) MaterialTheme.colorScheme.surface else Color.Transparent)
-                                            .clickable { selectedTextSize = index }
+                                            .background(if (isSelected) MaterialTheme.colorScheme.surface else Color.Transparent)
+                                            .clickable {
+                                                selectedTextSize = index
+                                                overlayScale = when (index) {
+                                                    0 -> 0.8f
+                                                    2 -> 1.2f
+                                                    else -> 1.0f
+                                                }
+                                            }
                                             .padding(vertical = 10.dp),
                                         contentAlignment = Alignment.Center
                                     ) {
                                         Text(
                                             text = label,
-                                            color = if (selectedTextSize == index) Color.White else Color.Gray,
-                                            fontWeight = if (selectedTextSize == index) FontWeight.Bold else FontWeight.Medium,
+                                            color = if (isSelected) Color.White else Color.Gray,
+                                            fontWeight = if (isSelected) FontWeight.Bold else FontWeight.Medium,
                                             fontSize = 14.sp
                                         )
                                     }
                                 }
                             }
+                            Spacer(modifier = Modifier.height(12.dp))
+                            Slider(
+                                value = overlayScale,
+                                onValueChange = { newScale ->
+                                    overlayScale = newScale
+                                    selectedTextSize = when {
+                                        kotlin.math.abs(newScale - 0.8f) < 0.05f -> 0
+                                        kotlin.math.abs(newScale - 1.0f) < 0.05f -> 1
+                                        kotlin.math.abs(newScale - 1.2f) < 0.05f -> 2
+                                        else -> -1
+                                    }
+                                },
+                                valueRange = 0.5f..1.5f,
+                                colors = SliderDefaults.colors(
+                                    thumbColor = Color.White,
+                                    activeTrackColor = colors[selectedColorIndex],
+                                    inactiveTrackColor = MaterialTheme.colorScheme.surfaceVariant
+                                )
+                            )
                         }
                         HorizontalDivider(color = Color.White.copy(0.05f))
                         Row(
@@ -394,7 +433,7 @@ fun AppearanceScreen(
             Button(
                 onClick = { 
                     if (hasChanges) {
-                        viewModel.saveSettings(opacity, selectedTextSize, useMonospace, selectedColorIndex, selectedBgColorIndex, selectedBorderColorIndex, selectedTextColorIndex)
+                        viewModel.saveSettings(opacity, overlayScale, useMonospace, selectedColorIndex, selectedBgColorIndex, selectedBorderColorIndex, selectedTextColorIndex)
                         Toast.makeText(context, "Appearance configuration saved!", Toast.LENGTH_SHORT).show()
                     }
                 },

--- a/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/OverlayCustomizationScreen.kt
@@ -62,6 +62,7 @@ class OverlayCustomizationViewModel @Inject constructor(
     val savedModuleOrder = settingsRepository.moduleOrder
     val opacity = settingsRepository.overlayOpacity
     val textSize = settingsRepository.overlayTextSize
+    val overlayScale = settingsRepository.overlayScale
     val useMonospace = settingsRepository.overlayUseMonospace
     val colorIndex = settingsRepository.overlayColorIndex
 
@@ -81,7 +82,7 @@ fun OverlayCustomizationScreen(
     val savedModules by viewModel.savedModules.collectAsState()
     val savedModuleOrder by viewModel.savedModuleOrder.collectAsState()
     val opacity by viewModel.opacity.collectAsState()
-    val textSize by viewModel.textSize.collectAsState()
+    val overlayScale by viewModel.overlayScale.collectAsState()
     val useMonospace by viewModel.useMonospace.collectAsState()
     val colorIndex by viewModel.colorIndex.collectAsState()
     val context = LocalContext.current
@@ -99,7 +100,7 @@ fun OverlayCustomizationScreen(
     )
     val accentColor = colors[colorIndex]
     val fontFamily = if (useMonospace) FontFamily.Monospace else MaterialTheme.typography.bodyMedium.fontFamily
-    val textScale = when (textSize) { 0 -> 0.8f; 2 -> 1.2f; else -> 1.0f }
+    val textScale = overlayScale
 
     val savedOrderIds = remember(savedModuleOrder) {
         val resolved = resolveMetricModuleOrder(savedModuleOrder)


### PR DESCRIPTION
### Summary
Closes #30.

Replaces the rigid 3-tier text size restriction with a continuous **Overlay Scale Slider (50% to 150%)** while maintaining full bi-directional correlation with existing **Small**, **Medium**, and **Large** preset buttons.

### Key Changes
- **SettingsRepository**: Added overlayScale: StateFlow<Float> (persisted key overlay_scale) with fallback logic for existing configurations.
- **AppearanceScreen**: Added continuous scale slider under preset buttons in the Typography section. Tapping presets snaps the slider, and dragging the slider highlights matching presets when near them.
- **Overlay Manager & Components**: Updated OverlayPreviewContent, OverlayManager, and OverlayCustomizationScreen to scale text and container padding dynamically using overlayScale.

### Verification
- Verified bi-directional preset and slider synchronization.
- Verified on physical device (Android 16).
- All unit tests pass cleanly.