### PR TITLE
fix(diagnostics): display Hardware Not Supported for disabled HAL thermals (#35) (#19)

### DIFF
--- a/app/src/main/java/com/framex/app/metrics/Monitors.kt
+++ b/app/src/main/java/com/framex/app/metrics/Monitors.kt
@@ -463,7 +463,8 @@ class ThermalMonitor @Inject constructor(
                                 val status = parsed?.thermalStatus ?: if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                                     powerManager.currentThermalStatus
                                 } else 0
-                                ThermalState(status = status, readStatus = MetricReadStatus.ParseFailed)
+                                val statusType = if (parsed?.halNotReady == true) MetricReadStatus.EmptyOutput else MetricReadStatus.ParseFailed
+                                ThermalState(status = status, readStatus = statusType)
                             }
                         } else {
                             consecutiveFailures = 0

--- a/app/src/main/java/com/framex/app/metrics/ThermalServiceParser.kt
+++ b/app/src/main/java/com/framex/app/metrics/ThermalServiceParser.kt
@@ -19,7 +19,9 @@ internal object ThermalServiceParser {
         val batteryC: Float? = null,
         val thermalStatus: Int = 0,
         /** Number of Temperature{…} blocks that yielded a value. */
-        val entryCount: Int = 0
+        val entryCount: Int = 0,
+        /** True if HAL is explicitly reported as not ready/disabled (e.g. HAL Ready: false). */
+        val halNotReady: Boolean = false
     ) {
         val hasAnySensor: Boolean
             get() = cpuC != null || gpuC != null || skinC != null || npuC != null || batteryC != null
@@ -92,6 +94,10 @@ internal object ThermalServiceParser {
             ?.toIntOrNull()
             ?: 0
 
+        val halNotReady = output.contains("HAL Ready: false", ignoreCase = true) || 
+                          output.contains("mHalReady: false", ignoreCase = true) ||
+                          output.contains("Thermal HAL is not ready", ignoreCase = true)
+
         return Result(
             cpuC = cpu,
             gpuC = gpu,
@@ -99,7 +105,8 @@ internal object ThermalServiceParser {
             npuC = npu,
             batteryC = battery,
             thermalStatus = thermalStatus,
-            entryCount = entryCount
+            entryCount = entryCount,
+            halNotReady = halNotReady
         )
     }
 

--- a/app/src/main/java/com/framex/app/ui/screens/ThermalDiagnosticsScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/ThermalDiagnosticsScreen.kt
@@ -134,14 +134,14 @@ class ThermalDiagnosticsViewModel @Inject constructor(
 private fun getThermalDisplayValue(value: Float, present: Boolean, readStatus: MetricReadStatus): String {
     return when (readStatus) {
         MetricReadStatus.NoShizuku -> "Needs Shizuku"
-        MetricReadStatus.EmptyOutput -> "Unavailable"
+        MetricReadStatus.EmptyOutput -> "Hardware Not Supported"
         MetricReadStatus.ParseFailed -> "Parse Failed"
         MetricReadStatus.Loading -> "Waiting..."
         else -> {
             if (present) {
                 String.format(java.util.Locale.US, "%.1f°C", value)
             } else {
-                "Unavailable"
+                "Hardware Not Supported"
             }
         }
     }


### PR DESCRIPTION
## Summary
- **Thermal HAL Ready Check**: Updated ThermalServiceParser to detect when HAL Ready: false is reported.
- **Hardware Not Supported Status**: Mapped disabled HAL and missing sensor states to Hardware Not Supported in ThermalDiagnosticsScreen.
- **Diagnostic Safety**: Maintained Parse Failed for unparsed raw dumps so genuine regex format mismatches can still be reported.