### PR TITLE
fix(metrics): add Qualcomm legacy thermal zone fallback and uninstalled app pruning (#46, #47)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.framex.app"
         minSdk = 26
         targetSdk = 34
-        versionCode = 12
-        versionName = "1.5.6"
+        versionCode = 14
+        versionName = "1.5.7-beta2"
     }
 
     buildFeatures {

--- a/app/src/main/java/com/framex/app/metrics/ThermalServiceParser.kt
+++ b/app/src/main/java/com/framex/app/metrics/ThermalServiceParser.kt
@@ -89,6 +89,18 @@ internal object ThermalServiceParser {
             }
         }
 
+        if (entryCount == 0) {
+            val fallback = parseFallbackZones(output)
+            if (fallback.entryCount > 0) {
+                cpu = fallback.cpuC
+                gpu = fallback.gpuC
+                skin = fallback.skinC
+                npu = fallback.npuC
+                battery = fallback.batteryC
+                entryCount = fallback.entryCount
+            }
+        }
+
         val thermalStatus = statusRegex.find(output)
             ?.groupValues?.get(1)
             ?.toIntOrNull()
@@ -110,11 +122,57 @@ internal object ThermalServiceParser {
         )
     }
 
+    private fun parseFallbackZones(output: String): Result {
+        val lines = output.lines().map { it.trim() }.filter { it.isNotBlank() }
+        val names = mutableListOf<Pair<Int, SensorKind>>()
+        val values = mutableListOf<Pair<Int, Float>>()
+
+        for ((idx, line) in lines.withIndex()) {
+            val num = line.toFloatOrNull()
+            if (num != null) {
+                val degC = if (kotlin.math.abs(num) > 200f) num / 1000f else num
+                if (degC in 0f..120f) {
+                    values.add(idx to degC)
+                }
+            } else {
+                val kind = classify(null, line)
+                if (kind != SensorKind.UNKNOWN) {
+                    names.add(idx to kind)
+                }
+            }
+        }
+
+        var cpu: Float? = null
+        var gpu: Float? = null
+        var skin: Float? = null
+        var npu: Float? = null
+        var battery: Float? = null
+        var count = 0
+
+        if (names.isNotEmpty() && values.isNotEmpty()) {
+            for ((nameIdx, kind) in names) {
+                val matchVal = values.firstOrNull { it.first >= nameIdx } ?: values.firstOrNull()
+                if (matchVal != null) {
+                    when (kind) {
+                        SensorKind.CPU -> if (cpu == null) { cpu = matchVal.second; count++ }
+                        SensorKind.GPU -> if (gpu == null) { gpu = matchVal.second; count++ }
+                        SensorKind.SKIN -> if (skin == null) { skin = matchVal.second; count++ }
+                        SensorKind.NPU -> if (npu == null) { npu = matchVal.second; count++ }
+                        SensorKind.BATTERY -> if (battery == null) { battery = matchVal.second; count++ }
+                        else -> {}
+                    }
+                }
+            }
+        }
+
+        return Result(cpuC = cpu, gpuC = gpu, skinC = skin, npuC = npu, batteryC = battery, entryCount = count)
+    }
+
     private enum class SensorKind { CPU, GPU, SKIN, NPU, BATTERY, UNKNOWN }
 
     /**
      * AOSP Temperature types: 0=CPU 1=GPU 2=BATTERY 3=SKIN 9=NPU.
-     * Name fallback is case-insensitive and matches common OEM labels.
+     * Name fallback is case-insensitive and matches common OEM/Qualcomm labels.
      */
     private fun classify(type: Int?, name: String): SensorKind {
         when (type) {
@@ -127,12 +185,11 @@ internal object ThermalServiceParser {
 
         val n = name.uppercase()
         return when {
-            n.contains("SKIN") -> SensorKind.SKIN
-            n.contains("GPU") || n.contains("GRAPHICS") -> SensorKind.GPU
-            n.contains("NPU") || n.contains("TPU") || n.contains("APU") -> SensorKind.NPU
+            n.contains("SKIN") || n.contains("QUIET_THERM") || n.contains("XO_THERM") -> SensorKind.SKIN
+            n.contains("GPU") || n.contains("GPUSS") || n.contains("GRAPHICS") -> SensorKind.GPU
+            n.contains("NPU") || n.contains("TPU") || n.contains("APU") || n.contains("Q6-HVX") -> SensorKind.NPU
             n.contains("BATTERY") || n.contains("BATT") -> SensorKind.BATTERY
-            // CPU last: many labels include "CPU" as a substring of longer names
-            n.contains("CPU") || n.contains("SOC") || n.contains("CLUSTER") -> SensorKind.CPU
+            n.contains("CPU") || n.contains("SOC") || n.contains("CLUSTER") || n.contains("CPUSS") -> SensorKind.CPU
             else -> SensorKind.UNKNOWN
         }
     }

--- a/app/src/main/java/com/framex/app/metrics/ThermalServiceParser.kt
+++ b/app/src/main/java/com/framex/app/metrics/ThermalServiceParser.kt
@@ -123,7 +123,46 @@ internal object ThermalServiceParser {
     }
 
     private fun parseFallbackZones(output: String): Result {
+        var cpu: Float? = null
+        var gpu: Float? = null
+        var skin: Float? = null
+        var npu: Float? = null
+        var battery: Float? = null
+        var count = 0
+
         val lines = output.lines().map { it.trim() }.filter { it.isNotBlank() }
+
+        // Strategy 1: Explicit name:value pair lines (from sh -c 'for z in ...; do echo "$name:$temp"; done')
+        for (line in lines) {
+            if (line.contains(":")) {
+                val parts = line.split(":").map { it.trim() }
+                if (parts.size >= 2) {
+                    val namePart = parts[parts.size - 2]
+                    val valPart = parts.last()
+                    val rawNum = valPart.toFloatOrNull()
+                    if (rawNum != null) {
+                        val degC = if (kotlin.math.abs(rawNum) > 200f) rawNum / 1000f else rawNum
+                        if (degC in 0f..120f) {
+                            val kind = classify(null, namePart)
+                            when (kind) {
+                                SensorKind.CPU -> if (cpu == null) { cpu = degC; count++ }
+                                SensorKind.GPU -> if (gpu == null) { gpu = degC; count++ }
+                                SensorKind.SKIN -> if (skin == null) { skin = degC; count++ }
+                                SensorKind.NPU -> if (npu == null) { npu = degC; count++ }
+                                SensorKind.BATTERY -> if (battery == null) { battery = degC; count++ }
+                                else -> {}
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        if (count > 0) {
+            return Result(cpuC = cpu, gpuC = gpu, skinC = skin, npuC = npu, batteryC = battery, entryCount = count)
+        }
+
+        // Strategy 2: Legacy fallback for unstructured text
         val names = mutableListOf<Pair<Int, SensorKind>>()
         val values = mutableListOf<Pair<Int, Float>>()
 
@@ -141,13 +180,6 @@ internal object ThermalServiceParser {
                 }
             }
         }
-
-        var cpu: Float? = null
-        var gpu: Float? = null
-        var skin: Float? = null
-        var npu: Float? = null
-        var battery: Float? = null
-        var count = 0
 
         if (names.isNotEmpty() && values.isNotEmpty()) {
             for ((nameIdx, kind) in names) {

--- a/app/src/main/java/com/framex/app/shizuku/CommandRunnerService.kt
+++ b/app/src/main/java/com/framex/app/shizuku/CommandRunnerService.kt
@@ -66,18 +66,18 @@ class CommandRunnerService(private val context: Context) : ICommandRunner.Stub()
                 }
             }
             val dump = executeCommand("dumpsys thermalservice")
-            if (dump.contains("Temperature{") || dump.contains("cpu-") || dump.contains("gpuss-") || dump.contains("quiet_therm")) {
+            if (dump.contains("Temperature{") || dump.contains("mValue=")) {
                 return dump
             }
             // Fallback for devices where dumpsys thermalservice outputs no sensor data (e.g. Redmi K20 Pro / HAL Ready: false)
-            val sysfsDump = executeCommand("cat /sys/class/thermal/thermal_zone*/type /sys/class/thermal/thermal_zone*/temp")
-            if (sysfsDump.isNotBlank()) {
+            val sysfsDump = executeCommand("sh -c 'for z in /sys/class/thermal/thermal_zone*; do echo \"\$(cat \$z/type 2>/dev/null):\$(cat \$z/temp 2>/dev/null)\"; done'")
+            if (sysfsDump.isNotBlank() && sysfsDump.contains(":")) {
                 return sysfsDump
             }
             return dump
         } catch (e: Exception) {
-            val sysfsDump = executeCommand("cat /sys/class/thermal/thermal_zone*/type /sys/class/thermal/thermal_zone*/temp")
-            if (sysfsDump.isNotBlank()) sysfsDump else executeCommand("dumpsys thermalservice")
+            val sysfsDump = executeCommand("sh -c 'for z in /sys/class/thermal/thermal_zone*; do echo \"\$(cat \$z/type 2>/dev/null):\$(cat \$z/temp 2>/dev/null)\"; done'")
+            if (sysfsDump.isNotBlank() && sysfsDump.contains(":")) sysfsDump else executeCommand("dumpsys thermalservice")
         }
     }
 

--- a/app/src/main/java/com/framex/app/shizuku/CommandRunnerService.kt
+++ b/app/src/main/java/com/framex/app/shizuku/CommandRunnerService.kt
@@ -65,9 +65,19 @@ class CommandRunnerService(private val context: Context) : ICommandRunner.Stub()
                     }
                 }
             }
-            executeCommand("dumpsys thermalservice")
+            val dump = executeCommand("dumpsys thermalservice")
+            if (dump.contains("Temperature{") || dump.contains("cpu-") || dump.contains("gpuss-") || dump.contains("quiet_therm")) {
+                return dump
+            }
+            // Fallback for devices where dumpsys thermalservice outputs no sensor data (e.g. Redmi K20 Pro / HAL Ready: false)
+            val sysfsDump = executeCommand("cat /sys/class/thermal/thermal_zone*/type /sys/class/thermal/thermal_zone*/temp")
+            if (sysfsDump.isNotBlank()) {
+                return sysfsDump
+            }
+            return dump
         } catch (e: Exception) {
-            executeCommand("dumpsys thermalservice")
+            val sysfsDump = executeCommand("cat /sys/class/thermal/thermal_zone*/type /sys/class/thermal/thermal_zone*/temp")
+            if (sysfsDump.isNotBlank()) sysfsDump else executeCommand("dumpsys thermalservice")
         }
     }
 

--- a/app/src/main/java/com/framex/app/ui/screens/performance/PerformanceViewModel.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/performance/PerformanceViewModel.kt
@@ -89,11 +89,23 @@ class PerformanceViewModel @Inject constructor(
 
     fun loadUserApps() {
         viewModelScope.launch {
-            _userApps.value = withContext(Dispatchers.IO) {
+            val installedUser = withContext(Dispatchers.IO) {
                 gamingModeEngine.getInstalledUserApps()
             }
-            _googleApps.value = withContext(Dispatchers.IO) {
+            val installedGoogle = withContext(Dispatchers.IO) {
                 gamingModeEngine.getGoogleAppsForWhitelist()
+            }
+            _userApps.value = installedUser
+            _googleApps.value = installedGoogle
+
+            // Auto-prune uninstalled packages from launcherGames
+            val installedPkgs = installedUser.map { it.packageName }.toSet()
+            if (installedPkgs.isNotEmpty()) {
+                val currentLauncher = settingsRepository.launcherGames.value
+                val validLauncher = currentLauncher.filter { it in installedPkgs }.toSet()
+                if (validLauncher.size != currentLauncher.size) {
+                    settingsRepository.setLauncherGames(validLauncher)
+                }
             }
         }
     }

--- a/app/src/main/java/com/framex/app/ui/screens/performance/sections/GameLauncherSection.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/performance/sections/GameLauncherSection.kt
@@ -73,21 +73,39 @@ fun GameLauncherSection(
             }
         } else {
             val userAppsMap = remember(userApps) { userApps.associateBy { it.packageName } }
+            // Filter launcherGames to only include packages that are actually installed on the device
+            val installedLauncherGames = remember(launcherGames, userAppsMap) {
+                if (userApps.isEmpty()) launcherGames.toList()
+                else launcherGames.filter { userAppsMap.containsKey(it) }
+            }
             
-            // Replaced chunked grid with LazyRow to eliminate forced spacer weights
-            LazyRow(
-                horizontalArrangement = Arrangement.spacedBy(12.dp),
-                contentPadding = PaddingValues(horizontal = 24.dp),
-                verticalAlignment = Alignment.CenterVertically
-            ) {
-                items(launcherGames.toList(), key = { it }) { pkg ->
-                    val app = userAppsMap[pkg] ?: AppInfo(pkg, pkg.substringAfterLast('.'))
-                    Card(
-                        modifier = Modifier.clickable { onGameConfigClicked(pkg) },
-                        shape = RoundedCornerShape(16.dp),
-                        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
-                        border = BorderStroke(1.dp, Color.White.copy(0.04f))
-                    ) {
+            if (installedLauncherGames.isEmpty()) {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = 24.dp)
+                        .height(120.dp)
+                        .clip(RoundedCornerShape(16.dp))
+                        .background(Color.White.copy(0.02f))
+                        .border(1.dp, Color.White.copy(0.04f), RoundedCornerShape(16.dp)),
+                    contentAlignment = Alignment.Center
+                ) {
+                    Text("No games added to launcher", color = Color.Gray, fontSize = 13.sp)
+                }
+            } else {
+                LazyRow(
+                    horizontalArrangement = Arrangement.spacedBy(12.dp),
+                    contentPadding = PaddingValues(horizontal = 24.dp),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    items(installedLauncherGames, key = { it }) { pkg ->
+                        val app = userAppsMap[pkg] ?: AppInfo(pkg, pkg.substringAfterLast('.'))
+                        Card(
+                            modifier = Modifier.clickable { onGameConfigClicked(pkg) },
+                            shape = RoundedCornerShape(16.dp),
+                            colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface),
+                            border = BorderStroke(1.dp, Color.White.copy(0.04f))
+                        ) {
                         Row(
                             modifier = Modifier
                                 .padding(horizontal = 16.dp, vertical = 12.dp),
@@ -141,6 +159,7 @@ fun GameLauncherSection(
                     }
                 }
             }
+        }
         }
 
         Spacer(modifier = Modifier.height(24.dp))


### PR DESCRIPTION
## Summary of Changes

### 1. Qualcomm Thermal Legacy Fallback Parser (#46)
- **Problem**: On Qualcomm Snapdragon devices reporting `HAL Ready: false`, `dumpsys thermalservice` outputs legacy sysfs thermal zone names (`cpuss-0-usr`, `gpuss-0-usr`, `quiet_therm`) and raw millidegree temperature values (`43200` = 43.2°C) instead of standard AOSP `Temperature{...}` objects. This caused CPU, GPU, Skin, and NPU to report "Hardware Not Supported".
- **Fix**: Added a fallback sysfs parser to `ThermalServiceParser.kt` that kicks in when 0 AOSP HAL blocks are found, mapping Qualcomm thermal streams directly to CPU, GPU, Skin, and NPU metrics.

### 2. Uninstalled Game Launcher Filtering & Auto-Pruning (#47)
- **Problem**: When a game is uninstalled from the device, its package string remained saved in `launcherGames`. `GameLauncherSection.kt` executed a fallback `pkg.substringAfterLast('.')` which parsed `com.tipsworks.android.passcalswager.google` as `"google"` with a `"GO"` placeholder icon.
- **Fix**: 
  - Filtered `GameLauncherSection.kt` to only render packages currently installed on the OS (`PackageManager.getInstalledApplications()`).
  - Added automatic pruning in `PerformanceViewModel.loadUserApps()` to remove uninstalled package references from saved preferences.

---

## Verification & Testing
- [x] Verified build succeeds via `./gradlew compileReleaseKotlin`
- [x] Tested app uninstallation handling: uninstalled test games are cleanly removed without ghost "google" cards.
- [x] Tested Qualcomm thermal fallback parsing logic against raw `dumpsys thermalservice` sensor dumps.
