### PR TITLE
feat(gaming): implement crash-safe snapshot recovery, Vivo Mode 4 display lock, and device reset slider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ plan2.md
 plan.md
 framex_session_20260722_024219.csv
 logs/*
+docs/VIVO/vivo_t3_ultra_full_device_audit.md
+docs/VIVO/*

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   <a href="https://github.com/MaheshSharan/FrameX-Android/releases/latest">
     <img src="https://img.shields.io/github/downloads/MaheshSharan/FrameX-Android/total?style=for-the-badge&logo=android&label=Total%20Downloads&color=4CAF50" alt="Total Downloads"/>
   </a>
-  <a href="https://github.com/MaheshSharan/FrameX-Android/releases/tag/v1.5.16">
-    <img src="https://img.shields.io/badge/Version-1.5.16-orange?style=for-the-badge&logo=github" alt="Version"/>
+  <a href="https://github.com/MaheshSharan/FrameX-Android/releases/tag/v1.5.17">
+    <img src="https://img.shields.io/badge/Version-1.5.17-orange?style=for-the-badge&logo=github" alt="Version"/>
   </a>
   <a href="https://developer.android.com/about/versions/oreo">
     <img src="https://img.shields.io/badge/API-26%2B-brightgreen?style=for-the-badge&logo=android" alt="Min API"/>
@@ -24,7 +24,7 @@
 
 ---
 >  [!NOTE]
-> **Gaming Performance Mode** is optimized specifically for **Android 16** and **Vivo OriginOS/FuntouchOS** devices. For Vivo/iQOO devices, enable the **Vivo Optimization** toggle in Settings (About) first to unlock maximum gaming performance and bypass dynamic thermal downclocking. Behavior on other Android skins may vary. Use this feature at your own risk.
+> **Gaming Performance Mode** is optimized specifically for **Android 16** and **Vivo OriginOS/FuntouchOS** devices (featuring hardware Mode 4 1080p @ 120Hz lock and 4 OEM Whitelists engine). For Vivo devices, enable **Vivo T3 Ultra Hardware Optimizations** in Settings (About) to unlock maximum gaming performance. Behavior on other Android skins may vary.
 
 > [!IMPORTANT]
 > **Encountering "Parse Failed" or "Unsupported Hardware"?**
@@ -49,11 +49,13 @@
 ---
 ## What it does
 
-FrameX shows a draggable, fully customisable overlay with live system stats on top of any app or game — including full-screen titles.
+FrameX displays a fully customizable, low-overhead overlay on top of any application or full-screen title.
 
-**Available metrics:** FPS · CPU frequency & core clusters · Multi-sensor Thermals (CPU, GPU, Skin, NPU, Battery) · RAM usage · Network speed · Ping
-
-**Performance Mode:** Optimize your device for gaming by suspending bloatware, restricting background apps, enabling advanced Do Not Disturb, deploying per-game display/volume configurations, and triggering OriginOS Esports hardware engines.
+| Category | Telemetry & Features |
+| :--- | :--- |
+| **Real-Time Telemetry** | **FPS** · **CPU Frequencies** · **Thermals** *(CPU/GPU/Skin/NPU/Battery)* · **RAM Usage** · **Network Speed** · **Ping** |
+| **System Optimization** | • **Crash-Safe Snapshots:** Automatic pre-game setting capture & auto-revert on exit<br>• **Process Management:** Background app suspension & Doze CPU whitelisting<br>• **Emergency Safety:** One-swipe reset slider to purge overrides back to stock OS defaults |
+| **OEM Hardware Locks** | • **Vivo OriginOS Engine:** Forces hardware Mode 4 ($1080 \times 2400$ @ 120Hz) lock<br>• **Triple Whitelisting:** Automatic injection across 4 native OriginOS game-booster daemons |
 
 ---
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.framex.app"
         minSdk = 26
         targetSdk = 34
-        versionCode = 22
-        versionName = "1.5.16"
+        versionCode = 23
+        versionName = "1.5.17"
     }
 
     buildFeatures {

--- a/app/src/main/aidl/com/framex/app/shizuku/CommandResult.aidl
+++ b/app/src/main/aidl/com/framex/app/shizuku/CommandResult.aidl
@@ -1,0 +1,6 @@
+package com.framex.app.shizuku;
+
+parcelable CommandResult {
+    String output;
+    int exitCode;
+}

--- a/app/src/main/aidl/com/framex/app/shizuku/ICommandRunner.aidl
+++ b/app/src/main/aidl/com/framex/app/shizuku/ICommandRunner.aidl
@@ -2,6 +2,7 @@ package com.framex.app.shizuku;
 
 interface ICommandRunner {
     String executeCommand(String command);
+    int executeCommandWithExitCode(String command);
     String getThermalTemperatures();
     int suspendPackages(in String[] packageNames, boolean suspended);
     int setAppOpMode(in String[] packageNames, int opCode, int mode);

--- a/app/src/main/aidl/com/framex/app/shizuku/ICommandRunner.aidl
+++ b/app/src/main/aidl/com/framex/app/shizuku/ICommandRunner.aidl
@@ -1,8 +1,12 @@
 package com.framex.app.shizuku;
 
+import com.framex.app.shizuku.CommandResult;
+
 interface ICommandRunner {
     String executeCommand(String command);
     int executeCommandWithExitCode(String command);
+    CommandResult executeCommandWithResult(String command);
+    String readProcStat();
     String getThermalTemperatures();
     int suspendPackages(in String[] packageNames, boolean suspended);
     int setAppOpMode(in String[] packageNames, int opCode, int mode);

--- a/app/src/main/java/com/framex/app/gaming/EsportsOptimizationEngine.kt
+++ b/app/src/main/java/com/framex/app/gaming/EsportsOptimizationEngine.kt
@@ -14,16 +14,15 @@ import javax.inject.Singleton
 import kotlin.math.abs
 
 /**
- * Result of a single Vivo/iQOO-specific gaming optimization execution.
+ * Result of a single Vivo T3 Ultra hardware optimization execution.
  * Each field is true only when the corresponding Shizuku command completed without error.
  * [maxHzApplied] carries the actual device max Hz used at activation time (not hardcoded).
  */
 data class VivoOptimizationResult(
-    val refreshRateLock: Boolean,
+    val displayModeLock: Boolean,
     val maxHzApplied: Int,
     val touchBoost: Boolean,
-    val competitionMode: Boolean,
-    val resolutionSwitch: Boolean,
+    val whitelistApplied: Boolean,
 )
 
 @Singleton
@@ -33,25 +32,104 @@ class EsportsOptimizationEngine @Inject constructor(
     private val settingsRepository: SettingsRepository,
     private val deviceDiagnosticManager: DeviceDiagnosticManager
 ) {
-    private var activeGamePackage: String? = null
-    private var activeGameUid: Int? = null
-    private var initialMinRefreshRate: String? = null
-    private var initialPeakRefreshRate: String? = null
-    private var initialVivoRefreshRateMode: String? = null
-    private var initialTouchSpeed: String? = null
-    private var initialVivoTouchPersist: String? = null
-    private var initialGameCubeCompetitionState: String? = null
-    private var initialGameScreenResolutionSwitch: String? = null
-
     private val _vivoOptimizationResult = MutableStateFlow<VivoOptimizationResult?>(null)
-    /** Null when gaming mode is inactive or device is not Vivo/iQOO. Non-null when active. */
+    /** Null when gaming mode is inactive or device is not Vivo T3 Ultra. Non-null when active. */
     val vivoOptimizationResult: StateFlow<VivoOptimizationResult?> = _vivoOptimizationResult.asStateFlow()
 
-    suspend fun applyOptimizationsForGame(packageName: String?, uid: Int?) {
-        if (!shizukuManager.isShizukuAvailable.value || !shizukuManager.hasPermission.value) return
+    // Vivo OEM whitelist key names (settings global CSV)
+    private val vivoWhitelistKeys = listOf(
+        "game_cube_apps",
+        "speed_mode_apps",
+        "vivo_high_refresh_rate_apps",
+        "vivo_screen_refresh_rate_apps_list"
+    )
 
-        activeGamePackage = packageName
-        activeGameUid = uid
+    /**
+     * Captures a snapshot of all system settings FrameX is about to modify.
+     * Returns null if any binder IPC command fails (indicating an un-restorable binder state).
+     */
+    private suspend fun captureSnapshot(packageName: String?, uid: Int?): GamingOptimizationSnapshot? {
+        val isVivo = deviceDiagnosticManager.isVivoOrIqoo() && settingsRepository.vivoOptEnabled.value
+
+        // Capture system settings (all devices)
+        val minRefreshResult = shizukuManager.executeCommandWithResult("settings get system min_refresh_rate")
+        val peakRefreshResult = shizukuManager.executeCommandWithResult("settings get system peak_refresh_rate")
+        val touchSpeedResult = shizukuManager.executeCommandWithResult("settings get system touch_response_speed")
+
+        if (minRefreshResult == null || peakRefreshResult == null || touchSpeedResult == null) {
+            FrameXLog.e("IPC failure capturing generic display/touch settings, aborting optimization", tag = TAG)
+            return null
+        }
+
+        val minRefresh = SettingValue.fromCommandOutput(minRefreshResult.output)
+        val peakRefresh = SettingValue.fromCommandOutput(peakRefreshResult.output)
+        val touchSpeed = SettingValue.fromCommandOutput(touchSpeedResult.output)
+
+        // Capture Vivo secure display mode (Group 1 mode 4)
+        val displayModeResult = shizukuManager.executeCommandWithResult("settings get secure user_preferred_display_mode_id")
+        if (displayModeResult == null) {
+            FrameXLog.e("IPC failure capturing user_preferred_display_mode_id, aborting optimization", tag = TAG)
+            return null
+        }
+        val userPreferredDisplayModeId = SettingValue.fromCommandOutput(displayModeResult.output)
+
+        // Capture Vivo global settings
+        var vivoRefreshMode: SettingValue? = null
+        var gameCubeApps: SettingValue? = null
+        var speedModeApps: SettingValue? = null
+        var vivoHighRefreshApps: SettingValue? = null
+        var vivoScreenRefreshAppsList: SettingValue? = null
+
+        if (isVivo) {
+            val vivoRrRes = shizukuManager.executeCommandWithResult("settings get global vivo_screen_refresh_rate_mode")
+            val gcAppsRes = shizukuManager.executeCommandWithResult("settings get global game_cube_apps")
+            val smAppsRes = shizukuManager.executeCommandWithResult("settings get global speed_mode_apps")
+            val hrAppsRes = shizukuManager.executeCommandWithResult("settings get global vivo_high_refresh_rate_apps")
+            val srAppsRes = shizukuManager.executeCommandWithResult("settings get global vivo_screen_refresh_rate_apps_list")
+
+            if (vivoRrRes == null || gcAppsRes == null || smAppsRes == null || hrAppsRes == null || srAppsRes == null) {
+                FrameXLog.e("IPC failure capturing Vivo OEM global settings, aborting optimization", tag = TAG)
+                return null
+            }
+
+            vivoRefreshMode = SettingValue.fromCommandOutput(vivoRrRes.output)
+            gameCubeApps = SettingValue.fromCommandOutput(gcAppsRes.output)
+            speedModeApps = SettingValue.fromCommandOutput(smAppsRes.output)
+            vivoHighRefreshApps = SettingValue.fromCommandOutput(hrAppsRes.output)
+            vivoScreenRefreshAppsList = SettingValue.fromCommandOutput(srAppsRes.output)
+        }
+
+        return GamingOptimizationSnapshot(
+            activeGamePackage = packageName,
+            activeGameUid = uid,
+            timestamp = System.currentTimeMillis(),
+            minRefreshRate = minRefresh,
+            peakRefreshRate = peakRefresh,
+            touchResponseSpeed = touchSpeed,
+            userPreferredDisplayModeId = userPreferredDisplayModeId,
+            vivoRefreshRateMode = vivoRefreshMode,
+            vivoTouchPersist = null,
+            gameCubeApps = gameCubeApps,
+            speedModeApps = speedModeApps,
+            vivoHighRefreshApps = vivoHighRefreshApps,
+            vivoScreenRefreshAppsList = vivoScreenRefreshAppsList,
+            affectedPackages = emptySet()
+        )
+    }
+
+    suspend fun applyOptimizationsForGame(packageName: String?, uid: Int?): Boolean {
+        if (!shizukuManager.isShizukuAvailable.value || !shizukuManager.hasPermission.value) return false
+
+        // Capture snapshot BEFORE making any changes
+        val snapshot = captureSnapshot(packageName, uid)
+        if (snapshot == null) {
+            FrameXLog.e("Snapshot capture failed, aborting optimizations", tag = TAG)
+            return false
+        }
+
+        // Save snapshot immediately
+        settingsRepository.saveGamingOptimizationSnapshot(snapshot)
+
         val isVivo = deviceDiagnosticManager.isVivoOrIqoo() && settingsRepository.vivoOptEnabled.value
 
         // 0. RAM Cache Pre-Trimming, ART Heap Compaction & Framework Pinning
@@ -59,15 +137,21 @@ class EsportsOptimizationEngine @Inject constructor(
         shizukuManager.executeCommand("am compact background")
         runCatching { shizukuManager.executeCommand("cmd pinner repin /system/framework/framework.jar") }
 
-        // 1. CPU Priority & Memory Lock (Android 16 Verified)
+        // 1. CPU Priority & Memory Lock
         if (settingsRepository.cpuPriorityLock.value && packageName != null) {
             shizukuManager.executeCommand("cmd activity set-bg-restriction-level --user 0 $packageName unrestricted")
             shizukuManager.executeCommand("am set-standby-bucket --user 0 $packageName active")
         }
 
-        // 2. Network Firewall & Light Doze
+        // 2. Network Firewall & Deep Doze Exemption
         if (settingsRepository.networkFirewall.value && uid != null) {
+            // Exempt socket restrictions in NetPolicy
             shizukuManager.executeCommand("cmd netpolicy add restrict-background-whitelist $uid")
+            // Exempt CPU process throttling in DeviceIdleController
+            if (!packageName.isNullOrBlank()) {
+                shizukuManager.executeCommand("cmd deviceidle whitelist +$packageName")
+            }
+            // Force Light/Deep Doze for non-whitelisted background processes
             shizukuManager.executeCommand("cmd deviceidle force-idle")
         }
 
@@ -75,64 +159,71 @@ class EsportsOptimizationEngine @Inject constructor(
         if (settingsRepository.fixedPerformanceMode.value) {
             shizukuManager.executeCommand("cmd power set-fixed-performance-mode-enabled true")
         }
-        // 4. Per-App Refresh Rate Lock & Android 16 Game Mode Downscaling Override
-        // maxHz is read from device hardware — never hardcoded. Supports 120, 144, 165+ Hz devices.
-        // Downscaling ratio 0.9x provides GPU/thermal headroom during intense hot drops.
+
+        // 4. Refresh Rate Lock & Display Mode Override
         val maxHz = deviceDiagnosticManager.getMaxHardwareRefreshRate()
-        var refreshRateLockOk = false
+        var displayModeLockOk = false
+
         if (settingsRepository.refreshRateLock.value) {
-            initialMinRefreshRate = shizukuManager.executeCommand("settings get system min_refresh_rate")
-            initialPeakRefreshRate = shizukuManager.executeCommand("settings get system peak_refresh_rate")
             shizukuManager.executeCommand("settings put system peak_refresh_rate $maxHz")
             shizukuManager.executeCommand("settings put system min_refresh_rate $maxHz")
+
             if (isVivo) {
-                initialVivoRefreshRateMode = shizukuManager.executeCommand("settings get global vivo_screen_refresh_rate_mode")
-                // cmd game set --fps and --downscale 0.9 require a specific package — skip during manual activation.
+                // Lock hardware display to Group 1 Mode 4 (1080x2400 @ 120Hz)
+                val modeResult = shizukuManager.executeCommandWithResult("settings put secure user_preferred_display_mode_id 4")
+                // Lock Vivo OEM display refresh rate mode
+                shizukuManager.executeCommand("settings put global vivo_screen_refresh_rate_mode 1")
+
                 if (!packageName.isNullOrBlank()) {
                     shizukuManager.executeCommand("cmd game set --fps ${maxHz.toInt()} --downscale 0.9 $packageName")
                 }
-                // Use global namespace — empirically verified on Vivo T3 Ultra (OriginOS 6).
-                val result = shizukuManager.executeCommand("settings put global vivo_screen_refresh_rate_mode ${maxHz.toInt()}")
-                refreshRateLockOk = !result.contains("error", ignoreCase = true)
+                displayModeLockOk = modeResult?.exitCode == 0
             } else {
-                refreshRateLockOk = true
+                displayModeLockOk = true
             }
         }
 
         // 5. Touch Response Latency Boost
         var touchBoostOk = false
         if (settingsRepository.touchBoost.value) {
-            initialTouchSpeed = shizukuManager.executeCommand("settings get system touch_response_speed")
-            shizukuManager.executeCommand("settings put system touch_response_speed 2")
-            if (isVivo) {
-                initialVivoTouchPersist = shizukuManager.executeCommand("settings get system com.vivo.vtouch.persist")
-                val result = shizukuManager.executeCommand("settings put system com.vivo.vtouch.persist 1")
-                touchBoostOk = !result.contains("error", ignoreCase = true)
-            } else {
-                touchBoostOk = true
-            }
+            // Universal Android touch response speed knob
+            val touchRes = shizukuManager.executeCommandWithResult("settings put system touch_response_speed 2")
+            touchBoostOk = touchRes?.exitCode == 0
+            // NOTE: Ghost key 'com.vivo.vtouch.persist' purged to eliminate redundant IPC overhead.
         }
 
-        // 6. Vivo GameCube Esports Boost (empirically verified writable on Vivo T3 Ultra)
-        var competitionModeOk: Boolean
-        var resolutionSwitchOk: Boolean
+        // 6. Vivo Whitelist Injection (Safe CSV Append)
+        var whitelistAppliedOk = false
         if (isVivo) {
-            initialGameCubeCompetitionState = shizukuManager.executeCommand("settings get system gamecube_competition_mode_state")
-            initialGameScreenResolutionSwitch = shizukuManager.executeCommand("settings get system game_screen_resolution_switch")
-            val compResult = shizukuManager.executeCommand("settings put system gamecube_competition_mode_state 1")
-            competitionModeOk = !compResult.contains("error", ignoreCase = true)
-            val resResult = shizukuManager.executeCommand("settings put system game_screen_resolution_switch 1")
-            resolutionSwitchOk = !resResult.contains("error", ignoreCase = true)
+            if (!packageName.isNullOrBlank()) {
+                var allSucceeded = true
+                for (key in vivoWhitelistKeys) {
+                    val currentValRes = shizukuManager.executeCommandWithResult("settings get global $key")
+                    val rawOutput = currentValRes?.output?.trim().orEmpty()
+                    val existingList = if (rawOutput == "null") "" else rawOutput
 
-            // Publish Vivo-specific execution result for UI status card
+                    val pkgs = existingList.split(",").map { it.trim() }.filter { it.isNotBlank() }.toMutableList()
+                    if (packageName !in pkgs) {
+                        pkgs.add(packageName)
+                        val newList = pkgs.joinToString(",")
+                        val writeRes = shizukuManager.executeCommandWithResult("settings put global $key \"$newList\"")
+                        if (writeRes?.exitCode != 0) allSucceeded = false
+                    }
+                }
+                whitelistAppliedOk = allSucceeded
+            } else {
+                whitelistAppliedOk = true
+            }
+
             _vivoOptimizationResult.value = VivoOptimizationResult(
-                refreshRateLock = refreshRateLockOk,
+                displayModeLock = displayModeLockOk,
                 maxHzApplied = maxHz.toInt(),
                 touchBoost = touchBoostOk,
-                competitionMode = competitionModeOk,
-                resolutionSwitch = resolutionSwitchOk,
+                whitelistApplied = whitelistAppliedOk
             )
         }
+
+        return true
     }
 
     suspend fun revertOptimizations() {
@@ -140,9 +231,17 @@ class EsportsOptimizationEngine @Inject constructor(
 
         recoverThermalOverrideIfNeeded()
 
-        val pkg = activeGamePackage
-        val uid = activeGameUid
+        val snapshot = settingsRepository.loadGamingOptimizationSnapshot()
+        if (snapshot == null) {
+            FrameXLog.w("No snapshot found, performing legacy revert", tag = TAG)
+            revertLegacy()
+            return
+        }
 
+        val pkg = snapshot.activeGamePackage
+        val uid = snapshot.activeGameUid
+
+        // Revert per-app overrides
         if (pkg != null) {
             shizukuManager.executeCommand("cmd game reset $pkg")
             if (settingsRepository.cpuPriorityLock.value) {
@@ -153,78 +252,78 @@ class EsportsOptimizationEngine @Inject constructor(
 
         if (uid != null && settingsRepository.networkFirewall.value) {
             shizukuManager.executeCommand("cmd netpolicy remove restrict-background-whitelist $uid")
+            if (!pkg.isNullOrBlank()) {
+                shizukuManager.executeCommand("cmd deviceidle whitelist -$pkg")
+            }
         }
         shizukuManager.executeCommand("cmd deviceidle unforce")
-
         shizukuManager.executeCommand("cmd power set-fixed-performance-mode-enabled false")
-        // Unlock thermal throttling — restores OEM default thermal management.
 
-        if (settingsRepository.refreshRateLock.value) {
-            val prevMin = initialMinRefreshRate
-            if (!prevMin.isNullOrBlank() && prevMin != "null") {
-                shizukuManager.executeCommand("settings put system min_refresh_rate $prevMin")
+        // Restore system display & touch settings
+        snapshot.minRefreshRate?.let { restoreSetting("system", "min_refresh_rate", it) }
+        snapshot.peakRefreshRate?.let { restoreSetting("system", "peak_refresh_rate", it) }
+        snapshot.touchResponseSpeed?.let { restoreSetting("system", "touch_response_speed", it) }
+
+        // Restore secure display mode ID (restore to -1 if absent)
+        snapshot.userPreferredDisplayModeId?.let { setting ->
+            if (setting.existed && setting.value.isNotBlank()) {
+                shizukuManager.executeCommand("settings put secure user_preferred_display_mode_id ${setting.value}")
             } else {
-                shizukuManager.executeCommand("settings delete system min_refresh_rate")
-            }
-
-            val prevPeak = initialPeakRefreshRate
-            if (!prevPeak.isNullOrBlank() && prevPeak != "null") {
-                shizukuManager.executeCommand("settings put system peak_refresh_rate $prevPeak")
-            } else {
-                shizukuManager.executeCommand("settings delete system peak_refresh_rate")
-            }
-
-            val prevVivoMode = initialVivoRefreshRateMode
-            if (!prevVivoMode.isNullOrBlank() && prevVivoMode != "null") {
-                shizukuManager.executeCommand("settings put global vivo_screen_refresh_rate_mode $prevVivoMode")
-            } else {
-                shizukuManager.executeCommand("settings put global vivo_screen_refresh_rate_mode 0")
-            }
-
-            // Force WindowManagerService / SurfaceFlinger policy recalculation
-            shizukuManager.executeCommand("settings put global user_refresh_rate 0")
-        }
-
-        if (settingsRepository.touchBoost.value) {
-            val prevTouch = initialTouchSpeed
-            if (!prevTouch.isNullOrBlank() && prevTouch != "null") {
-                shizukuManager.executeCommand("settings put system touch_response_speed $prevTouch")
-            } else {
-                shizukuManager.executeCommand("settings delete system touch_response_speed")
-            }
-
-            val prevVivoTouch = initialVivoTouchPersist
-            if (!prevVivoTouch.isNullOrBlank() && prevVivoTouch != "null") {
-                shizukuManager.executeCommand("settings put system com.vivo.vtouch.persist $prevVivoTouch")
-            } else {
-                shizukuManager.executeCommand("settings delete system com.vivo.vtouch.persist")
+                shizukuManager.executeCommand("settings put secure user_preferred_display_mode_id -1")
             }
         }
 
-        // Revert Vivo GameCube Esports Boost keys
-        val prevCompetition = initialGameCubeCompetitionState
-        if (!prevCompetition.isNullOrBlank() && prevCompetition != "null") {
-            shizukuManager.executeCommand("settings put system gamecube_competition_mode_state $prevCompetition")
+        // Restore Vivo global settings
+        snapshot.vivoRefreshRateMode?.let { restoreSetting("global", "vivo_screen_refresh_rate_mode", it) }
+
+        // Strip pkg from Vivo CSV whitelists
+        if (pkg != null) {
+            stripPackageFromCsv("game_cube_apps", pkg, snapshot.gameCubeApps)
+            stripPackageFromCsv("speed_mode_apps", pkg, snapshot.speedModeApps)
+            stripPackageFromCsv("vivo_high_refresh_rate_apps", pkg, snapshot.vivoHighRefreshApps)
+            stripPackageFromCsv("vivo_screen_refresh_rate_apps_list", pkg, snapshot.vivoScreenRefreshAppsList)
+        }
+
+        // Clear snapshot only after successful restoration
+        settingsRepository.clearGamingOptimizationSnapshot()
+        _vivoOptimizationResult.value = null
+    }
+
+    private suspend fun restoreSetting(namespace: String, key: String, setting: SettingValue) {
+        if (setting.existed && setting.value.isNotBlank()) {
+            shizukuManager.executeCommand("settings put $namespace $key ${setting.value}")
         } else {
-            shizukuManager.executeCommand("settings delete system gamecube_competition_mode_state")
+            shizukuManager.executeCommand("settings delete $namespace $key")
         }
-        val prevResSwitch = initialGameScreenResolutionSwitch
-        if (!prevResSwitch.isNullOrBlank() && prevResSwitch != "null") {
-            shizukuManager.executeCommand("settings put system game_screen_resolution_switch $prevResSwitch")
-        } else {
-            shizukuManager.executeCommand("settings delete system game_screen_resolution_switch")
-        }
+    }
 
-        activeGamePackage = null
-        activeGameUid = null
-        initialMinRefreshRate = null
-        initialPeakRefreshRate = null
-        initialVivoRefreshRateMode = null
-        initialTouchSpeed = null
-        initialVivoTouchPersist = null
-        initialGameCubeCompetitionState = null
-        initialGameScreenResolutionSwitch = null
-        // Clear Vivo status — device is no longer in gaming mode
+    private suspend fun stripPackageFromCsv(key: String, pkg: String, originalBackup: SettingValue?) {
+        val currentValRes = shizukuManager.executeCommandWithResult("settings get global $key")
+        val rawOutput = currentValRes?.output?.trim().orEmpty()
+        if (rawOutput.isNotBlank() && rawOutput != "null") {
+            val pkgs = rawOutput.split(",").map { it.trim() }.filter { it.isNotBlank() && it != pkg }
+            if (pkgs.isNotEmpty()) {
+                shizukuManager.executeCommand("settings put global $key \"${pkgs.joinToString(",")}\"")
+            } else {
+                if (originalBackup != null && originalBackup.existed && originalBackup.value.isNotBlank()) {
+                    shizukuManager.executeCommand("settings put global $key \"${originalBackup.value}\"")
+                } else {
+                    shizukuManager.executeCommand("settings delete global $key")
+                }
+            }
+        } else if (originalBackup != null) {
+            restoreSetting("global", key, originalBackup)
+        }
+    }
+
+    private suspend fun revertLegacy() {
+        shizukuManager.executeCommand("settings delete system min_refresh_rate")
+        shizukuManager.executeCommand("settings delete system peak_refresh_rate")
+        shizukuManager.executeCommand("settings put secure user_preferred_display_mode_id -1")
+        shizukuManager.executeCommand("settings delete global vivo_screen_refresh_rate_mode")
+        shizukuManager.executeCommand("settings delete system touch_response_speed")
+        shizukuManager.executeCommand("cmd power set-fixed-performance-mode-enabled false")
+        shizukuManager.executeCommand("cmd deviceidle unforce")
         _vivoOptimizationResult.value = null
     }
 
@@ -232,15 +331,83 @@ class EsportsOptimizationEngine @Inject constructor(
         if (!settingsRepository.needsThermalOverrideRecovery()) return true
         if (!shizukuManager.isShizukuAvailable.value || !shizukuManager.hasPermission.value) return false
 
-        val exitCode = shizukuManager.executeCommandWithExitCode("cmd thermalservice reset")
-        if (exitCode != 0) {
-            FrameXLog.w("Thermal override recovery failed with exit code $exitCode", tag = "GamingMode")
+        val result = shizukuManager.executeCommandWithResult("cmd thermalservice reset")
+        if (result == null || result.exitCode != 0) {
+            FrameXLog.w("Thermal override recovery failed", tag = TAG)
             return false
         }
 
         settingsRepository.markThermalOverrideRecoveryComplete()
-        FrameXLog.i("Thermal override recovery completed", tag = "GamingMode")
+        FrameXLog.i("Thermal override recovery completed", tag = TAG)
         return true
+    }
+
+    suspend fun performLegacyCleanupIfNeeded(): Boolean {
+        if (!settingsRepository.needsLegacySettingsCleanup()) return true
+        if (!shizukuManager.isShizukuAvailable.value || !shizukuManager.hasPermission.value) return false
+
+        FrameXLog.i("Performing one-time legacy settings cleanup", tag = TAG)
+
+        val cleanupCommands = listOf(
+            "settings delete system min_refresh_rate",
+            "settings delete system peak_refresh_rate",
+            "settings put secure user_preferred_display_mode_id -1",
+            "settings delete global vivo_screen_refresh_rate_mode",
+            "settings delete system touch_response_speed",
+            "settings delete global com.vivo.vtouch.persist",
+            "settings delete system com.vivo.vtouch.persist",
+            "settings delete system game_screen_resolution_switch",
+            "settings delete system gamecube_competition_mode_state",
+            "cmd power set-fixed-performance-mode-enabled false",
+            "cmd thermalservice reset"
+        )
+
+        var allSucceeded = true
+        for (cmd in cleanupCommands) {
+            val result = shizukuManager.executeCommandWithResult(cmd)
+            if (result == null || result.exitCode != 0) {
+                allSucceeded = false
+            }
+        }
+
+        if (allSucceeded) {
+            settingsRepository.markLegacySettingsCleanupComplete()
+            FrameXLog.i("Legacy settings cleanup completed successfully", tag = TAG)
+        }
+
+        return allSucceeded
+    }
+
+    suspend fun resetToDeviceDefaults(forceReset: Boolean = false): Boolean {
+        if (!forceReset && !settingsRepository.needsLegacySettingsCleanup()) return true
+        if (!shizukuManager.isShizukuAvailable.value || !shizukuManager.hasPermission.value) return false
+
+        FrameXLog.i("User-triggered device defaults reset", tag = TAG)
+
+        val resetCommands = listOf(
+            "settings delete system min_refresh_rate",
+            "settings delete system peak_refresh_rate",
+            "settings put secure user_preferred_display_mode_id -1",
+            "settings delete global vivo_screen_refresh_rate_mode",
+            "settings delete system touch_response_speed",
+            "cmd power set-fixed-performance-mode-enabled false",
+            "cmd thermalservice reset",
+            "cmd deviceidle unforce"
+        )
+
+        var successCount = 0
+        for (cmd in resetCommands) {
+            val result = shizukuManager.executeCommandWithResult(cmd)
+            if (result != null && result.exitCode == 0) {
+                successCount++
+            }
+        }
+
+        settingsRepository.markLegacySettingsCleanupComplete()
+        settingsRepository.clearGamingOptimizationSnapshot()
+
+        FrameXLog.i("Device defaults reset: $successCount/${resetCommands.size} commands succeeded", tag = TAG)
+        return successCount == resetCommands.size
     }
 
     fun calculateFramePacingDeltaMs(actualFps: Int): Float {
@@ -249,5 +416,9 @@ class EsportsOptimizationEngine @Inject constructor(
         val targetFrameTimeMs = 1000f / activeHz
         val actualFrameTimeMs = 1000f / actualFps.toFloat()
         return abs(actualFrameTimeMs - targetFrameTimeMs)
+    }
+
+    private companion object {
+        const val TAG = "EsportsEngine"
     }
 }

--- a/app/src/main/java/com/framex/app/gaming/EsportsOptimizationEngine.kt
+++ b/app/src/main/java/com/framex/app/gaming/EsportsOptimizationEngine.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.framex.app.device.DeviceDiagnosticManager
 import com.framex.app.repository.SettingsRepository
 import com.framex.app.shizuku.ShizukuManager
+import com.framex.app.utils.FrameXLog
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -18,7 +19,6 @@ import kotlin.math.abs
  * [maxHzApplied] carries the actual device max Hz used at activation time (not hardcoded).
  */
 data class VivoOptimizationResult(
-    val thermalOverride: Boolean,
     val refreshRateLock: Boolean,
     val maxHzApplied: Int,
     val touchBoost: Boolean,
@@ -71,17 +71,10 @@ class EsportsOptimizationEngine @Inject constructor(
             shizukuManager.executeCommand("cmd deviceidle force-idle")
         }
 
-        // 3. Performance Governor Lock + Active Thermal Throttling Override
-        // cmd thermalservice override-status 0: empirically verified on Vivo T3 Ultra (ADB shell UID 2000).
-        // Locks Android ThermalManager to THERMAL_STATUS_NONE, preventing OEM frame-rate throttling drops.
+        // 3. Performance Governor Lock
         if (settingsRepository.fixedPerformanceMode.value) {
             shizukuManager.executeCommand("cmd power set-fixed-performance-mode-enabled true")
         }
-        val thermalOverrideOk = runCatching {
-            shizukuManager.executeCommand("cmd thermalservice override-status 0")
-            true
-        }.getOrDefault(false)
-
         // 4. Per-App Refresh Rate Lock & Android 16 Game Mode Downscaling Override
         // maxHz is read from device hardware — never hardcoded. Supports 120, 144, 165+ Hz devices.
         // Downscaling ratio 0.9x provides GPU/thermal headroom during intense hot drops.
@@ -133,7 +126,6 @@ class EsportsOptimizationEngine @Inject constructor(
 
             // Publish Vivo-specific execution result for UI status card
             _vivoOptimizationResult.value = VivoOptimizationResult(
-                thermalOverride = thermalOverrideOk,
                 refreshRateLock = refreshRateLockOk,
                 maxHzApplied = maxHz.toInt(),
                 touchBoost = touchBoostOk,
@@ -145,6 +137,8 @@ class EsportsOptimizationEngine @Inject constructor(
 
     suspend fun revertOptimizations() {
         if (!shizukuManager.isShizukuAvailable.value || !shizukuManager.hasPermission.value) return
+
+        recoverThermalOverrideIfNeeded()
 
         val pkg = activeGamePackage
         val uid = activeGameUid
@@ -164,7 +158,6 @@ class EsportsOptimizationEngine @Inject constructor(
 
         shizukuManager.executeCommand("cmd power set-fixed-performance-mode-enabled false")
         // Unlock thermal throttling — restores OEM default thermal management.
-        shizukuManager.executeCommand("cmd thermalservice reset")
 
         if (settingsRepository.refreshRateLock.value) {
             val prevMin = initialMinRefreshRate
@@ -233,6 +226,21 @@ class EsportsOptimizationEngine @Inject constructor(
         initialGameScreenResolutionSwitch = null
         // Clear Vivo status — device is no longer in gaming mode
         _vivoOptimizationResult.value = null
+    }
+
+    suspend fun recoverThermalOverrideIfNeeded(): Boolean {
+        if (!settingsRepository.needsThermalOverrideRecovery()) return true
+        if (!shizukuManager.isShizukuAvailable.value || !shizukuManager.hasPermission.value) return false
+
+        val exitCode = shizukuManager.executeCommandWithExitCode("cmd thermalservice reset")
+        if (exitCode != 0) {
+            FrameXLog.w("Thermal override recovery failed with exit code $exitCode", tag = "GamingMode")
+            return false
+        }
+
+        settingsRepository.markThermalOverrideRecoveryComplete()
+        FrameXLog.i("Thermal override recovery completed", tag = "GamingMode")
+        return true
     }
 
     fun calculateFramePacingDeltaMs(actualFps: Int): Float {

--- a/app/src/main/java/com/framex/app/gaming/GamingModeEngine.kt
+++ b/app/src/main/java/com/framex/app/gaming/GamingModeEngine.kt
@@ -317,13 +317,37 @@ class GamingModeEngine @Inject constructor(
             // Apply Esports optimizations for all activations.
             // When activeGamePkg is null (manual activation), package-specific commands like
             // cmd game set --fps are skipped, but all system-wide Vivo/thermal boosts still run.
-            try {
+            // Apply Esports optimizations for all activations.
+            // When activeGamePkg is null (manual activation), package-specific commands like
+            // cmd game set --fps are skipped, but all system-wide Vivo/thermal boosts still run.
+            val optimizationsApplied = try {
                 val uid = activeGamePkg?.let {
                     runCatching { context.packageManager.getPackageUid(it, 0) }.getOrNull()
                 }
                 esportsOptimizationEngine.applyOptimizationsForGame(activeGamePkg, uid)
             } catch (e: Exception) {
                 com.framex.app.utils.FrameXLog.w("Esports optimization failed", e)
+                false
+            }
+
+            if (!optimizationsApplied) {
+                // Esports snapshot capture failed, abort gaming mode activation
+                _state.value = GamingModeState.Error("Failed to capture system settings snapshot")
+                // Clean up what we've done so far
+                if (!isAlreadyActive) {
+                    val allToUnsuspend = (SAFE_TO_SUSPEND + affectedPkgs).distinct()
+                    shizukuManager.suspendPackages(allToUnsuspend, false)
+                }
+                settingsRepository.setGamingModeActive(false)
+                _isActive.value = false
+                return
+            }
+
+            // Update snapshot with affected packages (now that suspension is complete)
+            val currentSnapshot = settingsRepository.loadGamingOptimizationSnapshot()
+            currentSnapshot?.let { snapshot ->
+                val updatedSnapshot = snapshot.copy(affectedPackages = affectedPkgs)
+                settingsRepository.saveGamingOptimizationSnapshot(updatedSnapshot)
             }
 
             // ----------------------------------------------------------------
@@ -346,13 +370,15 @@ class GamingModeEngine @Inject constructor(
      * 1. pm unsuspend on SAFE_TO_SUSPEND
      * 2. pm unsuspend + restore AppOps on previously-affected user packages
      * 3. Disable DND
+     * 4. Restore esports optimizations from snapshot
      */
     suspend fun disableGamingMode() {
         _state.value = GamingModeState.Disabling
 
         try {
-            // Unsuspend all OEM packages and user packages in a single batched IPC call
-            val affectedUserPkgs = settingsRepository.getGamingAffectedPackages()
+            // Load snapshot to get affected packages
+            val snapshot = settingsRepository.loadGamingOptimizationSnapshot()
+            val affectedUserPkgs = snapshot?.affectedPackages ?: settingsRepository.getGamingAffectedPackages()
             val allToUnsuspend = (SAFE_TO_SUSPEND + affectedUserPkgs).distinct()
 
             shizukuManager.suspendPackages(allToUnsuspend, false)
@@ -414,7 +440,22 @@ class GamingModeEngine @Inject constructor(
     /** Called on app start-up to recover state that was active before a kill. */
     fun recoverPersistedState() {
         recoverThermalOverrideIfNeeded()
-        if (settingsRepository.isGamingModeActive()) {
+        recoverLegacySettingsIfNeeded()
+
+        // Check for orphaned gaming optimization snapshot
+        if (settingsRepository.hasActiveGamingSnapshot()) {
+            com.framex.app.utils.FrameXLog.w("Detected orphaned gaming optimization snapshot, will recover on Shizuku connect", tag = "GamingMode")
+            _isActive.value = true
+            _state.value = GamingModeState.Active
+
+            if (shizukuManager.isShizukuAvailable.value && shizukuManager.hasPermission.value) {
+                recoveryScope.launch {
+                    disableGamingMode()
+                }
+            } else {
+                showRecoveryNotification()
+            }
+        } else if (settingsRepository.isGamingModeActive()) {
             _isActive.value = true
             _state.value = GamingModeState.Active
             if (!shizukuManager.isShizukuAvailable.value || !shizukuManager.hasPermission.value) {
@@ -436,6 +477,22 @@ class GamingModeEngine @Inject constructor(
                 .distinctUntilChanged()
                 .filter { it }
                 .first { esportsOptimizationEngine.recoverThermalOverrideIfNeeded() }
+        }
+    }
+
+    private fun recoverLegacySettingsIfNeeded() {
+        if (!settingsRepository.needsLegacySettingsCleanup()) return
+
+        recoveryScope.launch {
+            combine(
+                shizukuManager.isShizukuAvailable,
+                shizukuManager.hasPermission
+            ) { available, granted ->
+                available && granted
+            }
+                .distinctUntilChanged()
+                .filter { it }
+                .first { esportsOptimizationEngine.performLegacyCleanupIfNeeded() }
         }
     }
 

--- a/app/src/main/java/com/framex/app/gaming/GamingModeEngine.kt
+++ b/app/src/main/java/com/framex/app/gaming/GamingModeEngine.kt
@@ -11,10 +11,18 @@ import android.provider.Settings
 import com.framex.app.repository.SettingsRepository
 import com.framex.app.shizuku.ShizukuManager
 import dagger.hilt.android.qualifiers.ApplicationContext
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.filter
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -48,6 +56,9 @@ class GamingModeEngine @Inject constructor(
     private val esportsOptimizationEngine: EsportsOptimizationEngine,
     private val oemPackageResolver: OemPackageResolver
 ) {
+
+    private val recoveryScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private var thermalRecoveryJob: Job? = null
 
     // ---- Public state -------------------------------------------------------
 
@@ -350,8 +361,6 @@ class GamingModeEngine @Inject constructor(
             // Purge spawned background processes after unsuspending to prevent Vivo PEM battery drain
             shizukuManager.executeCommand("am kill-all")
 
-            esportsOptimizationEngine.revertOptimizations()
-
             // Restore DND
             val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             if (nm.isNotificationPolicyAccessGranted) {
@@ -389,21 +398,44 @@ class GamingModeEngine @Inject constructor(
 
         } catch (e: Exception) {
             com.framex.app.utils.FrameXLog.w("Error during Gaming Mode deactivation", e)
-        }
+        } finally {
+            try {
+                esportsOptimizationEngine.revertOptimizations()
+            } catch (e: Exception) {
+                com.framex.app.utils.FrameXLog.w("Esports optimization cleanup failed", e)
+            }
 
-        settingsRepository.setGamingModeActive(false)
-        _isActive.value = false
-        _state.value = GamingModeState.Idle
+            settingsRepository.setGamingModeActive(false)
+            _isActive.value = false
+            _state.value = GamingModeState.Idle
+        }
     }
 
     /** Called on app start-up to recover state that was active before a kill. */
     fun recoverPersistedState() {
+        recoverThermalOverrideIfNeeded()
         if (settingsRepository.isGamingModeActive()) {
             _isActive.value = true
             _state.value = GamingModeState.Active
             if (!shizukuManager.isShizukuAvailable.value || !shizukuManager.hasPermission.value) {
                 showRecoveryNotification()
             }
+        }
+    }
+
+    private fun recoverThermalOverrideIfNeeded() {
+        if (!settingsRepository.needsThermalOverrideRecovery() || thermalRecoveryJob?.isActive == true) return
+
+        thermalRecoveryJob = recoveryScope.launch {
+            combine(
+                shizukuManager.isShizukuAvailable,
+                shizukuManager.hasPermission
+            ) { available, granted ->
+                available && granted
+            }
+                .distinctUntilChanged()
+                .filter { it }
+                .first { esportsOptimizationEngine.recoverThermalOverrideIfNeeded() }
         }
     }
 

--- a/app/src/main/java/com/framex/app/gaming/GamingOptimizationSnapshot.kt
+++ b/app/src/main/java/com/framex/app/gaming/GamingOptimizationSnapshot.kt
@@ -1,0 +1,135 @@
+package com.framex.app.gaming
+
+import org.json.JSONArray
+import org.json.JSONObject
+
+/**
+ * Persisted snapshot of every system setting FrameX modifies during Gaming Mode activation.
+ * Stored before the first modification and restored on deactivation. Allows crash-safe recovery.
+ */
+data class GamingOptimizationSnapshot(
+    // Session metadata
+    val activeGamePackage: String?,
+    val activeGameUid: Int?,
+    val timestamp: Long,
+    
+    // Android system settings (system namespace)
+    val minRefreshRate: SettingValue?,
+    val peakRefreshRate: SettingValue?,
+    val touchResponseSpeed: SettingValue?,
+    
+    // Secure settings (secure namespace)
+    val userPreferredDisplayModeId: SettingValue?,
+    
+    // Vivo global settings (global namespace)
+    val vivoRefreshRateMode: SettingValue?,
+    val vivoTouchPersist: SettingValue?,
+    
+    // Vivo global whitelist CSV keys
+    val gameCubeApps: SettingValue?,
+    val speedModeApps: SettingValue?,
+    val vivoHighRefreshApps: SettingValue?,
+    val vivoScreenRefreshAppsList: SettingValue?,
+    
+    // App state tracking
+    val affectedPackages: Set<String>
+) {
+    
+    fun toJson(): String {
+        val json = JSONObject()
+        json.put("activeGamePackage", activeGamePackage ?: JSONObject.NULL)
+        json.put("activeGameUid", activeGameUid ?: JSONObject.NULL)
+        json.put("timestamp", timestamp)
+        
+        json.put("minRefreshRate", minRefreshRate?.toJson() ?: JSONObject.NULL)
+        json.put("peakRefreshRate", peakRefreshRate?.toJson() ?: JSONObject.NULL)
+        json.put("touchResponseSpeed", touchResponseSpeed?.toJson() ?: JSONObject.NULL)
+        json.put("userPreferredDisplayModeId", userPreferredDisplayModeId?.toJson() ?: JSONObject.NULL)
+        json.put("vivoRefreshRateMode", vivoRefreshRateMode?.toJson() ?: JSONObject.NULL)
+        json.put("vivoTouchPersist", vivoTouchPersist?.toJson() ?: JSONObject.NULL)
+        
+        json.put("gameCubeApps", gameCubeApps?.toJson() ?: JSONObject.NULL)
+        json.put("speedModeApps", speedModeApps?.toJson() ?: JSONObject.NULL)
+        json.put("vivoHighRefreshApps", vivoHighRefreshApps?.toJson() ?: JSONObject.NULL)
+        json.put("vivoScreenRefreshAppsList", vivoScreenRefreshAppsList?.toJson() ?: JSONObject.NULL)
+        
+        val pkgsArray = JSONArray()
+        affectedPackages.forEach { pkgsArray.put(it) }
+        json.put("affectedPackages", pkgsArray)
+        
+        return json.toString()
+    }
+    
+    companion object {
+        fun fromJson(jsonStr: String): GamingOptimizationSnapshot? {
+            return try {
+                val json = JSONObject(jsonStr)
+                
+                val affectedPkgs = mutableSetOf<String>()
+                if (json.has("affectedPackages")) {
+                    val pkgsArray = json.getJSONArray("affectedPackages")
+                    for (i in 0 until pkgsArray.length()) {
+                        affectedPkgs.add(pkgsArray.getString(i))
+                    }
+                }
+                
+                GamingOptimizationSnapshot(
+                    activeGamePackage = if (json.isNull("activeGamePackage")) null else json.getString("activeGamePackage"),
+                    activeGameUid = if (json.isNull("activeGameUid")) null else json.getInt("activeGameUid"),
+                    timestamp = json.getLong("timestamp"),
+                    minRefreshRate = if (json.isNull("minRefreshRate")) null else SettingValue.fromJson(json.getJSONObject("minRefreshRate")),
+                    peakRefreshRate = if (json.isNull("peakRefreshRate")) null else SettingValue.fromJson(json.getJSONObject("peakRefreshRate")),
+                    touchResponseSpeed = if (json.isNull("touchResponseSpeed")) null else SettingValue.fromJson(json.getJSONObject("touchResponseSpeed")),
+                    userPreferredDisplayModeId = if (json.isNull("userPreferredDisplayModeId")) null else SettingValue.fromJson(json.getJSONObject("userPreferredDisplayModeId")),
+                    vivoRefreshRateMode = if (json.isNull("vivoRefreshRateMode")) null else SettingValue.fromJson(json.getJSONObject("vivoRefreshRateMode")),
+                    vivoTouchPersist = if (json.isNull("vivoTouchPersist")) null else SettingValue.fromJson(json.getJSONObject("vivoTouchPersist")),
+                    gameCubeApps = if (json.isNull("gameCubeApps")) null else SettingValue.fromJson(json.getJSONObject("gameCubeApps")),
+                    speedModeApps = if (json.isNull("speedModeApps")) null else SettingValue.fromJson(json.getJSONObject("speedModeApps")),
+                    vivoHighRefreshApps = if (json.isNull("vivoHighRefreshApps")) null else SettingValue.fromJson(json.getJSONObject("vivoHighRefreshApps")),
+                    vivoScreenRefreshAppsList = if (json.isNull("vivoScreenRefreshAppsList")) null else SettingValue.fromJson(json.getJSONObject("vivoScreenRefreshAppsList")),
+                    affectedPackages = affectedPkgs
+                )
+            } catch (e: Exception) {
+                com.framex.app.utils.FrameXLog.e("Failed to parse GamingOptimizationSnapshot from JSON", e)
+                null
+            }
+        }
+    }
+}
+
+/**
+ * Represents a system setting value with existence tracking.
+ * If [existed] is false, the setting key was absent before FrameX wrote it.
+ */
+data class SettingValue(
+    val value: String,
+    val existed: Boolean
+) {
+    fun toJson(): JSONObject {
+        val json = JSONObject()
+        json.put("value", value)
+        json.put("existed", existed)
+        return json
+    }
+    
+    companion object {
+        fun fromJson(json: JSONObject): SettingValue {
+            return SettingValue(
+                value = json.getString("value"),
+                existed = json.getBoolean("existed")
+            )
+        }
+        
+        /**
+         * Create SettingValue from settings command output.
+         * Returns SettingValue("", existed = false) if output is "null" or empty.
+         */
+        fun fromCommandOutput(output: String): SettingValue {
+            val trimmed = output.trim()
+            return when {
+                trimmed.isEmpty() || trimmed == "null" -> SettingValue("", existed = false)
+                else -> SettingValue(trimmed, existed = true)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/framex/app/metrics/Monitors.kt
+++ b/app/src/main/java/com/framex/app/metrics/Monitors.kt
@@ -178,7 +178,7 @@ class CpuMonitor @Inject constructor(
             try {
                 val output = if (shizukuManager.isShizukuAvailable.value && shizukuManager.hasPermission.value) {
                     try {
-                        shizukuManager.executeCommand("cat /proc/stat")
+                        shizukuManager.readProcStat()
                     } catch (e: Exception) {
                         ""
                     }
@@ -618,7 +618,7 @@ class TopProcessMonitor @Inject constructor(
             }
 
             emit(result)
-            delay(1000)
+            delay(2000)
         }
     }
 }

--- a/app/src/main/java/com/framex/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/framex/app/repository/SettingsRepository.kt
@@ -233,6 +233,15 @@ class SettingsRepository @Inject constructor(
     fun getGamingAffectedPackages(): Set<String> =
         prefs.getStringSet(KEY_GAMING_AFFECTED_PKGS, emptySet()) ?: emptySet()
 
+    fun needsThermalOverrideRecovery(): Boolean =
+        prefs.getInt(KEY_THERMAL_OVERRIDE_RECOVERY_VERSION, 0) < THERMAL_OVERRIDE_RECOVERY_VERSION
+
+    fun markThermalOverrideRecoveryComplete() {
+        prefs.edit()
+            .putInt(KEY_THERMAL_OVERRIDE_RECOVERY_VERSION, THERMAL_OVERRIDE_RECOVERY_VERSION)
+            .apply()
+    }
+
     // ---- Game Launcher ------------------------------------------------------
 
     private val _launcherGames = MutableStateFlow(
@@ -370,6 +379,8 @@ class SettingsRepository @Inject constructor(
         private const val KEY_GAMING_WHITELIST = "gaming_mode_whitelist"
         private const val KEY_GAMING_MODE_ACTIVE = "gaming_mode_active"
         private const val KEY_GAMING_AFFECTED_PKGS = "gaming_affected_pkgs"
+        private const val KEY_THERMAL_OVERRIDE_RECOVERY_VERSION = "thermal_override_recovery_version"
+        private const val THERMAL_OVERRIDE_RECOVERY_VERSION = 1
         private const val KEY_LAUNCHER_GAMES = "launcher_games"
         private const val KEY_VIVO_OPT_ENABLED = "esports_vivo_opt_enabled"
         private const val KEY_CPU_PRIORITY_LOCK = "esports_cpu_priority_lock"

--- a/app/src/main/java/com/framex/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/framex/app/repository/SettingsRepository.kt
@@ -282,7 +282,7 @@ class SettingsRepository @Inject constructor(
 
     // ---- Esports Optimizations ----------------------------------------------
 
-    private val _vivoOptEnabled = MutableStateFlow(prefs.getBoolean(KEY_VIVO_OPT_ENABLED, false))
+    private val _vivoOptEnabled = MutableStateFlow(prefs.getBoolean(KEY_VIVO_OPT_ENABLED, true))
     val vivoOptEnabled: StateFlow<Boolean> = _vivoOptEnabled.asStateFlow()
 
     private val _cpuPriorityLock = MutableStateFlow(prefs.getBoolean(KEY_CPU_PRIORITY_LOCK, true))
@@ -354,6 +354,49 @@ class SettingsRepository @Inject constructor(
         _overlayWasRunning.value = running
     }
 
+    // ---- Gaming Optimization Snapshot (Crash-Safe Recovery) -----------------
+
+    /**
+     * Saves the current gaming optimization snapshot.
+     */
+    fun saveGamingOptimizationSnapshot(snapshot: com.framex.app.gaming.GamingOptimizationSnapshot) {
+        prefs.edit().putString(KEY_GAMING_OPT_SNAPSHOT, snapshot.toJson()).apply()
+    }
+
+    /**
+     * Loads the persisted gaming optimization snapshot, if any.
+     * Returns null if no active snapshot exists or if deserialization fails.
+     */
+    fun loadGamingOptimizationSnapshot(): com.framex.app.gaming.GamingOptimizationSnapshot? {
+        val json = prefs.getString(KEY_GAMING_OPT_SNAPSHOT, null) ?: return null
+        return com.framex.app.gaming.GamingOptimizationSnapshot.fromJson(json)
+    }
+
+    /**
+     * Clears the persisted gaming optimization snapshot. Call only after successful restoration.
+     */
+    fun clearGamingOptimizationSnapshot() {
+        prefs.edit().remove(KEY_GAMING_OPT_SNAPSHOT).apply()
+    }
+
+    /**
+     * Returns true if there is an active gaming optimization snapshot that needs recovery.
+     */
+    fun hasActiveGamingSnapshot(): Boolean {
+        return prefs.contains(KEY_GAMING_OPT_SNAPSHOT)
+    }
+
+    // ---- Legacy Cleanup Migration --------------------------------------------
+
+    fun needsLegacySettingsCleanup(): Boolean =
+        prefs.getInt(KEY_LEGACY_SETTINGS_CLEANUP_VERSION, 0) < LEGACY_SETTINGS_CLEANUP_VERSION
+
+    fun markLegacySettingsCleanupComplete() {
+        prefs.edit()
+            .putInt(KEY_LEGACY_SETTINGS_CLEANUP_VERSION, LEGACY_SETTINGS_CLEANUP_VERSION)
+            .apply()
+    }
+
     companion object {
         private const val KEY_OVERLAY_MODE = "overlay_mode"
         private const val KEY_THERMAL_TIME_WINDOW = "thermal_time_window"
@@ -391,5 +434,8 @@ class SettingsRepository @Inject constructor(
         private const val KEY_FIXED_PERFORMANCE_MODE = "esports_fixed_performance_mode"
         private const val KEY_AUTO_UPDATE_CHECK_ENABLED = "auto_update_check_enabled"
         private const val KEY_OVERLAY_WAS_RUNNING = "overlay_was_running"
+        private const val KEY_GAMING_OPT_SNAPSHOT = "gaming_opt_snapshot"
+        private const val KEY_LEGACY_SETTINGS_CLEANUP_VERSION = "legacy_settings_cleanup_version"
+        private const val LEGACY_SETTINGS_CLEANUP_VERSION = 1
     }
 }

--- a/app/src/main/java/com/framex/app/shizuku/CommandRunnerService.kt
+++ b/app/src/main/java/com/framex/app/shizuku/CommandRunnerService.kt
@@ -49,6 +49,21 @@ class CommandRunnerService private constructor(
         }
     }
 
+    override fun executeCommandWithExitCode(command: String): Int {
+        return try {
+            val process = ProcessBuilder("sh", "-c", command)
+                .redirectErrorStream(true)
+                .start()
+            BufferedReader(InputStreamReader(process.inputStream)).use { reader ->
+                reader.readText()
+            }
+            process.waitFor()
+        } catch (e: Exception) {
+            com.framex.app.utils.FrameXLog.e("Error executing command: $command", e)
+            COMMAND_EXECUTION_FAILED
+        }
+    }
+
     override fun getThermalTemperatures(): String {
         resolvedThermalStrategy?.let { cached ->
             val cachedResult = readUsingStrategy(cached)
@@ -321,5 +336,9 @@ class CommandRunnerService private constructor(
 
     override fun destroy() {
         exitProcess(0)
+    }
+
+    private companion object {
+        const val COMMAND_EXECUTION_FAILED = -1
     }
 }

--- a/app/src/main/java/com/framex/app/shizuku/CommandRunnerService.kt
+++ b/app/src/main/java/com/framex/app/shizuku/CommandRunnerService.kt
@@ -64,6 +64,37 @@ class CommandRunnerService private constructor(
         }
     }
 
+    override fun executeCommandWithResult(command: String): CommandResult {
+        return try {
+            val process = ProcessBuilder("sh", "-c", command)
+                .redirectErrorStream(true)
+                .start()
+            val output = BufferedReader(InputStreamReader(process.inputStream)).use { reader ->
+                reader.readText().trim()
+            }
+            val exitCode = process.waitFor()
+            CommandResult().apply {
+                this.output = output
+                this.exitCode = exitCode
+            }
+        } catch (e: Exception) {
+            com.framex.app.utils.FrameXLog.e("Error executing command with result: $command", e)
+            CommandResult().apply {
+                this.output = "Error executing command: ${e.message}"
+                this.exitCode = COMMAND_EXECUTION_FAILED
+            }
+        }
+    }
+
+    override fun readProcStat(): String {
+        return try {
+            java.io.File("/proc/stat").readText()
+        } catch (e: Exception) {
+            com.framex.app.utils.FrameXLog.w("Direct /proc/stat read failed, falling back to shell", e)
+            executeCommand("cat /proc/stat")
+        }
+    }
+
     override fun getThermalTemperatures(): String {
         resolvedThermalStrategy?.let { cached ->
             val cachedResult = readUsingStrategy(cached)

--- a/app/src/main/java/com/framex/app/shizuku/ShizukuManager.kt
+++ b/app/src/main/java/com/framex/app/shizuku/ShizukuManager.kt
@@ -168,6 +168,48 @@ class ShizukuManager @Inject constructor() {
         }
     }
 
+    suspend fun executeCommandWithResult(command: String): CommandResult? {
+        if (!_isShizukuAvailable.value || !_hasPermission.value) {
+            com.framex.app.utils.FrameXLog.w("executeCommandWithResult called when Shizuku is unavailable or permission is not granted")
+            return null
+        }
+        return commandMutex.withLock {
+            val runner = awaitCommandRunner() ?: run {
+                com.framex.app.utils.FrameXLog.w("CommandRunner unavailable after bind attempt in executeCommandWithResult")
+                return@withLock null
+            }
+            try {
+                withContext(Dispatchers.IO) {
+                    runner.executeCommandWithResult(command)
+                }
+            } catch (e: Exception) {
+                com.framex.app.utils.FrameXLog.e("executeCommandWithResult failed: $command", e)
+                null
+            }
+        }
+    }
+
+    suspend fun readProcStat(): String {
+        if (!_isShizukuAvailable.value || !_hasPermission.value) {
+            com.framex.app.utils.FrameXLog.w("readProcStat called when Shizuku is unavailable")
+            return ""
+        }
+        return commandMutex.withLock {
+            val runner = awaitCommandRunner() ?: run {
+                com.framex.app.utils.FrameXLog.w("CommandRunner unavailable after bind attempt in readProcStat")
+                return@withLock ""
+            }
+            try {
+                withContext(Dispatchers.IO) {
+                    runner.readProcStat()
+                }
+            } catch (e: Exception) {
+                com.framex.app.utils.FrameXLog.e("readProcStat failed", e)
+                ""
+            }
+        }
+    }
+
     suspend fun getThermalTemperatures(): String {
         if (!_isShizukuAvailable.value || !_hasPermission.value) {
             com.framex.app.utils.FrameXLog.w("getThermalTemperatures called when Shizuku is unavailable")

--- a/app/src/main/java/com/framex/app/shizuku/ShizukuManager.kt
+++ b/app/src/main/java/com/framex/app/shizuku/ShizukuManager.kt
@@ -147,6 +147,27 @@ class ShizukuManager @Inject constructor() {
         }
     }
 
+    suspend fun executeCommandWithExitCode(command: String): Int {
+        if (!_isShizukuAvailable.value || !_hasPermission.value) {
+            com.framex.app.utils.FrameXLog.w("executeCommandWithExitCode called when Shizuku is unavailable or permission is not granted")
+            return COMMAND_EXECUTION_FAILED
+        }
+        return commandMutex.withLock {
+            val runner = awaitCommandRunner() ?: run {
+                com.framex.app.utils.FrameXLog.w("CommandRunner unavailable after bind attempt in executeCommandWithExitCode")
+                return@withLock COMMAND_EXECUTION_FAILED
+            }
+            try {
+                withContext(Dispatchers.IO) {
+                    runner.executeCommandWithExitCode(command)
+                }
+            } catch (e: Exception) {
+                com.framex.app.utils.FrameXLog.e("executeCommandWithExitCode failed: $command", e)
+                COMMAND_EXECUTION_FAILED
+            }
+        }
+    }
+
     suspend fun getThermalTemperatures(): String {
         if (!_isShizukuAvailable.value || !_hasPermission.value) {
             com.framex.app.utils.FrameXLog.w("getThermalTemperatures called when Shizuku is unavailable")
@@ -300,5 +321,6 @@ class ShizukuManager @Inject constructor() {
         private const val BIND_TIMEOUT_MS = 5000L
         private const val INITIAL_BIND_DELAY_MS = 2000L
         private const val USER_SERVICE_TAG = "framex-command-runner"
+        private const val COMMAND_EXECUTION_FAILED = -1
     }
 }

--- a/app/src/main/java/com/framex/app/ui/components/VivoDiagnosticDialog.kt
+++ b/app/src/main/java/com/framex/app/ui/components/VivoDiagnosticDialog.kt
@@ -62,7 +62,7 @@ fun VivoDiagnosticDialog(
                 Spacer(modifier = Modifier.height(16.dp))
 
                 Text(
-                    text = if (isVivoOrIqoo) "Vivo / iQOO Detected" else "Device Compatibility Notice",
+                    text = if (isVivoOrIqoo) "Vivo T3 Ultra / Vivo OEM Detected" else "Device Compatibility Notice",
                     color = Color.White,
                     fontSize = 20.sp,
                     fontWeight = FontWeight.Bold,
@@ -83,9 +83,9 @@ fun VivoDiagnosticDialog(
 
                 Text(
                     text = if (isVivoOrIqoo) {
-                        "Your hardware supports OriginOS / FuntouchOS performance governor overrides. Enabling will unlock OEM specific power modes & touch boost."
+                        "Your hardware supports OriginOS performance governor overrides. Enabling will unlock OEM specific power modes, touch boost, and 1080p@120Hz display lock."
                     } else {
-                        "Your device is not manufactured by Vivo/iQOO. FrameX will apply universal Android 12–16 optimizations (CPU priority lock, netpolicy firewall, and refresh rate lock) which work 100% reliably on your phone."
+                        "Your device is not manufactured by Vivo. FrameX will apply universal Android 12–16 optimizations (CPU priority lock, netpolicy firewall, and refresh rate lock) which work 100% reliably on your phone."
                     },
                     color = Color.Gray,
                     fontSize = 13.sp,

--- a/app/src/main/java/com/framex/app/ui/screens/AboutScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/AboutScreen.kt
@@ -369,7 +369,7 @@ fun AboutScreen(
                                 }
                                 Spacer(modifier = Modifier.width(14.dp))
                                 Column(modifier = Modifier.weight(1f)) {
-                                    Text("Vivo / iQOO Hardware Optimizations", color = Color.White, fontWeight = FontWeight.SemiBold, fontSize = 15.5.sp)
+                                    Text("Vivo T3 Ultra Hardware Optimizations", color = Color.White, fontWeight = FontWeight.SemiBold, fontSize = 15.5.sp)
                                     Spacer(modifier = Modifier.height(2.dp))
                                     Text("Enable OriginOS / FuntouchOS OEM power governor overrides.", color = Color.White.copy(alpha = 0.6f), fontSize = 12.5.sp)
                                 }

--- a/app/src/main/java/com/framex/app/ui/screens/performance/PerformanceScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/performance/PerformanceScreen.kt
@@ -124,6 +124,8 @@ fun PerformanceScreen(
     var showRamResult by remember { mutableStateOf(false) }
     var isOptimizingNet by remember { mutableStateOf(false) }
     var showPingResult by remember { mutableStateOf(false) }
+    var isResettingDefaults by remember { mutableStateOf(false) }
+    var showResetResult by remember { mutableStateOf(false) }
     var showRamSuccessBanner by remember { mutableStateOf<String?>(null) }
     var activeLatencyDiagnostic by remember { mutableStateOf<Int?>(null) }
 
@@ -212,6 +214,8 @@ fun PerformanceScreen(
                     showRamResult = showRamResult,
                     isOptimizingNet = isOptimizingNet,
                     showPingResult = showPingResult,
+                    isResettingDefaults = isResettingDefaults,
+                    showResetResult = showResetResult,
                     onBoostRam = {
                         scope.launch {
                             isBoostingRam = true
@@ -235,6 +239,19 @@ fun PerformanceScreen(
                             showRamSuccessBanner = if (pingRes != null) "Latency check complete: $pingRes ms" else "Latency check failed: network unreachable"
                             delay(2500)
                             showPingResult = false
+                            delay(300)
+                            showRamSuccessBanner = null
+                        }
+                    },
+                    onResetDefaults = {
+                        scope.launch {
+                            isResettingDefaults = true
+                            val resetOk = viewModel.resetToDeviceDefaults()
+                            isResettingDefaults = false
+                            showResetResult = true
+                            showRamSuccessBanner = if (resetOk) "Device settings reset to OS defaults" else "Device reset partially completed"
+                            delay(2500)
+                            showResetResult = false
                             delay(300)
                             showRamSuccessBanner = null
                         }

--- a/app/src/main/java/com/framex/app/ui/screens/performance/PerformanceViewModel.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/performance/PerformanceViewModel.kt
@@ -256,6 +256,9 @@ class PerformanceViewModel @Inject constructor(
         }
     }
 
+    suspend fun resetToDeviceDefaults(): Boolean =
+        esportsOptimizationEngine.resetToDeviceDefaults(forceReset = true)
+
     val safeToSuspendList: List<String> get() = gamingModeEngine.SAFE_TO_SUSPEND
     val googleSafeToSuspendList: List<String> get() = gamingModeEngine.GOOGLE_SAFE_TO_SUSPEND
     val gamingDaemonsList: List<String>

--- a/app/src/main/java/com/framex/app/ui/screens/performance/sections/HeroGamingCard.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/performance/sections/HeroGamingCard.kt
@@ -338,22 +338,20 @@ private fun VivoBoostStatusCard(result: VivoOptimizationResult) {
                 )
                 Spacer(modifier = Modifier.width(8.dp))
                 Text(
-                    "Vivo / iQOO Hardware Boost",
+                    "Vivo T3 Ultra Hardware Boost",
                     color = accentColor,
                     fontWeight = FontWeight.Bold,
                     fontSize = 13.sp
                 )
             }
             HorizontalDivider(color = accentColor.copy(alpha = 0.15f))
-            // maxHzApplied comes from the device's actual hardware max Hz — not hardcoded
             VivoStatusRow(
-                "Refresh Rate Lock",
-                "${result.maxHzApplied} Hz (Device Max) Locked",
-                result.refreshRateLock
+                "Display Mode Lock (Mode 4)",
+                "1080p @ ${result.maxHzApplied} Hz Locked",
+                result.displayModeLock
             )
             VivoStatusRow("Touch Latency Boost", "vtouch.persist Active", result.touchBoost)
-            VivoStatusRow("Competition Mode", "GameCube Esports Mode Active", result.competitionMode)
-            VivoStatusRow("Resolution Switch", "Game Resolution Control Active", result.resolutionSwitch)
+            VivoStatusRow("OEM Game Whitelists", "4 Whitelists Appended", result.whitelistApplied)
         }
     }
 }

--- a/app/src/main/java/com/framex/app/ui/screens/performance/sections/HeroGamingCard.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/performance/sections/HeroGamingCard.kt
@@ -346,7 +346,6 @@ private fun VivoBoostStatusCard(result: VivoOptimizationResult) {
             }
             HorizontalDivider(color = accentColor.copy(alpha = 0.15f))
             // maxHzApplied comes from the device's actual hardware max Hz — not hardcoded
-            VivoStatusRow("Thermal Override", "THERMAL_STATUS_NONE Active", result.thermalOverride)
             VivoStatusRow(
                 "Refresh Rate Lock",
                 "${result.maxHzApplied} Hz (Device Max) Locked",

--- a/app/src/main/java/com/framex/app/ui/screens/performance/sections/OptimizationSlidersSection.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/performance/sections/OptimizationSlidersSection.kt
@@ -3,6 +3,7 @@ package com.framex.app.ui.screens.performance.sections
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Bolt
+import androidx.compose.material.icons.filled.RestoreFromTrash
 import androidx.compose.material.icons.filled.SettingsInputAntenna
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -18,8 +19,11 @@ fun OptimizationSlidersSection(
     showRamResult: Boolean,
     isOptimizingNet: Boolean,
     showPingResult: Boolean,
+    isResettingDefaults: Boolean,
+    showResetResult: Boolean,
     onBoostRam: () -> Unit,
-    onCheckPing: () -> Unit
+    onCheckPing: () -> Unit,
+    onResetDefaults: () -> Unit
 ) {
     Column(modifier = Modifier.padding(horizontal = 24.dp)) {
         Text(
@@ -50,6 +54,20 @@ fun OptimizationSlidersSection(
             resultText = "CHECKED",
             onActivated = onCheckPing
         )
+
+        Spacer(modifier = Modifier.height(12.dp))
+
+        SwipeToActivate(
+            text = "SWIPE TO RESET DEVICE DEFAULTS",
+            icon = Icons.Default.RestoreFromTrash,
+            accentColor = Color(0xFFF59E0B),
+            isBusy = isResettingDefaults,
+            showResult = showResetResult,
+            busyText = "RESETTING…",
+            resultText = "RESET DONE",
+            onActivated = onResetDefaults
+        )
+
         Spacer(modifier = Modifier.height(24.dp))
     }
 }


### PR DESCRIPTION
## What's Changed
* Implemented persistent \`GamingOptimizationSnapshot\` with \`SettingValue(value, existed)\` key existence tracking for crash-safe state recovery.
* Added automatic recovery of orphaned gaming sessions on app startup or Shizuku reconnect.
* Locked Vivo hardware display directly to Mode 4 ($1080 \times 2400$ @ 120Hz) via \`user_preferred_display_mode_id 4\` (restored to \`-1\` at rest).
* Implemented safe CSV whitelist injection engine targeting \`game_cube_apps\`, \`speed_mode_apps\`, \`vivo_high_refresh_rate_apps\`, and \`vivo_screen_refresh_rate_apps_list\` without clobbering existing entries.
* Added Doze CPU process whitelist exemption (\`cmd deviceidle whitelist +<pkg>\`) alongside \`netpolicy\` socket restrictions.
* Added third amber swipe slider (\`SWIPE TO RESET DEVICE DEFAULTS\`) on Performance screen to purge overrides back to clean OS defaults.
* Purged non-existent OEM ghost keys (\`gamecube_competition_mode_state\`, \`game_screen_resolution_switch\`, \`touch_smooth\`, \`com.vivo.vtouch.persist\`).
* Optimized diagnostic monitoring: direct JVM \`/proc/stat\` reader (0 shell forks/hour) and 2000ms Top Process sampling cadence.