### PR TITLE
fix(gaming): implement transactional deactivation and IPC verification (#66)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   <a href="https://github.com/MaheshSharan/FrameX-Android/releases/latest">
     <img src="https://img.shields.io/github/downloads/MaheshSharan/FrameX-Android/total?style=for-the-badge&logo=android&label=Total%20Downloads&color=4CAF50" alt="Total Downloads"/>
   </a>
-  <a href="https://github.com/MaheshSharan/FrameX-Android/releases/tag/v1.5.18">
-    <img src="https://img.shields.io/badge/Version-1.5.18-orange?style=for-the-badge&logo=github" alt="Version"/>
+  <a href="https://github.com/MaheshSharan/FrameX-Android/releases/tag/v1.5.19">
+    <img src="https://img.shields.io/badge/Version-1.5.19-orange?style=for-the-badge&logo=github" alt="Version"/>
   </a>
   <a href="https://developer.android.com/about/versions/oreo">
     <img src="https://img.shields.io/badge/API-26%2B-brightgreen?style=for-the-badge&logo=android" alt="Min API"/>

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.framex.app"
         minSdk = 26
         targetSdk = 34
-        versionCode = 24
-        versionName = "1.5.18"
+        versionCode = 25
+        versionName = "1.5.19"
     }
 
     buildFeatures {

--- a/app/src/main/aidl/com/framex/app/shizuku/ICommandRunner.aidl
+++ b/app/src/main/aidl/com/framex/app/shizuku/ICommandRunner.aidl
@@ -1,6 +1,7 @@
 package com.framex.app.shizuku;
 
 import com.framex.app.shizuku.CommandResult;
+import com.framex.app.shizuku.SuspendResult;
 
 interface ICommandRunner {
     String executeCommand(String command);
@@ -8,7 +9,7 @@ interface ICommandRunner {
     CommandResult executeCommandWithResult(String command);
     String readProcStat();
     String getThermalTemperatures();
-    int suspendPackages(in String[] packageNames, boolean suspended);
+    SuspendResult suspendPackages(in String[] packageNames, boolean suspended);
     int setAppOpMode(in String[] packageNames, int opCode, int mode);
     void destroy();
 }

--- a/app/src/main/aidl/com/framex/app/shizuku/SuspendResult.aidl
+++ b/app/src/main/aidl/com/framex/app/shizuku/SuspendResult.aidl
@@ -1,0 +1,6 @@
+package com.framex.app.shizuku;
+
+parcelable SuspendResult {
+    String[] failedPackages;
+    int successCount;
+}

--- a/app/src/main/java/com/framex/app/gaming/EsportsOptimizationEngine.kt
+++ b/app/src/main/java/com/framex/app/gaming/EsportsOptimizationEngine.kt
@@ -99,6 +99,9 @@ class EsportsOptimizationEngine @Inject constructor(
             vivoScreenRefreshAppsList = SettingValue.fromCommandOutput(srAppsRes.output)
         }
 
+        val existingSnapshot = settingsRepository.loadGamingOptimizationSnapshot()
+        val existingAffected = existingSnapshot?.affectedPackages ?: settingsRepository.getGamingAffectedPackages()
+
         return GamingOptimizationSnapshot(
             activeGamePackage = packageName,
             activeGameUid = uid,
@@ -113,7 +116,7 @@ class EsportsOptimizationEngine @Inject constructor(
             speedModeApps = speedModeApps,
             vivoHighRefreshApps = vivoHighRefreshApps,
             vivoScreenRefreshAppsList = vivoScreenRefreshAppsList,
-            affectedPackages = emptySet()
+            affectedPackages = existingAffected
         )
     }
 
@@ -131,16 +134,19 @@ class EsportsOptimizationEngine @Inject constructor(
         settingsRepository.saveGamingOptimizationSnapshot(snapshot)
 
         val isVivo = deviceDiagnosticManager.isVivoOrIqoo() && settingsRepository.vivoOptEnabled.value
+        FrameXLog.i("Applying Esports Optimizations (pkg=$packageName, uid=$uid, isVivo=$isVivo)", tag = TAG)
 
         // 0. RAM Cache Pre-Trimming, ART Heap Compaction & Framework Pinning
         shizukuManager.executeCommand("pm trim-caches 4G")
         shizukuManager.executeCommand("am compact background")
         runCatching { shizukuManager.executeCommand("cmd pinner repin /system/framework/framework.jar") }
+        FrameXLog.i("RAM cache pre-trimming & ART heap compaction executed", tag = TAG)
 
         // 1. CPU Priority & Memory Lock
         if (settingsRepository.cpuPriorityLock.value && packageName != null) {
             shizukuManager.executeCommand("cmd activity set-bg-restriction-level --user 0 $packageName unrestricted")
             shizukuManager.executeCommand("am set-standby-bucket --user 0 $packageName active")
+            FrameXLog.i("CPU Priority & Standby Bucket active set for $packageName", tag = TAG)
         }
 
         // 2. Network Firewall & Deep Doze Exemption
@@ -153,11 +159,13 @@ class EsportsOptimizationEngine @Inject constructor(
             }
             // Force Light/Deep Doze for non-whitelisted background processes
             shizukuManager.executeCommand("cmd deviceidle force-idle")
+            FrameXLog.i("Network Firewall & Deep Doze exemption applied (uid=$uid, pkg=$packageName)", tag = TAG)
         }
 
         // 3. Performance Governor Lock
         if (settingsRepository.fixedPerformanceMode.value) {
             shizukuManager.executeCommand("cmd power set-fixed-performance-mode-enabled true")
+            FrameXLog.i("Fixed performance mode enabled", tag = TAG)
         }
 
         // 4. Refresh Rate Lock & Display Mode Override
@@ -167,6 +175,7 @@ class EsportsOptimizationEngine @Inject constructor(
         if (settingsRepository.refreshRateLock.value) {
             shizukuManager.executeCommand("settings put system peak_refresh_rate $maxHz")
             shizukuManager.executeCommand("settings put system min_refresh_rate $maxHz")
+            FrameXLog.i("Refresh rate set to peak/min $maxHz Hz", tag = TAG)
 
             if (isVivo) {
                 // Lock hardware display to Group 1 Mode 4 (1080x2400 @ 120Hz)
@@ -178,6 +187,7 @@ class EsportsOptimizationEngine @Inject constructor(
                     shizukuManager.executeCommand("cmd game set --fps ${maxHz.toInt()} --downscale 0.9 $packageName")
                 }
                 displayModeLockOk = modeResult?.exitCode == 0
+                FrameXLog.i("Vivo hardware display mode lock (user_preferred_display_mode_id 4) applied: ok=$displayModeLockOk", tag = TAG)
             } else {
                 displayModeLockOk = true
             }
@@ -186,16 +196,14 @@ class EsportsOptimizationEngine @Inject constructor(
         // 5. Touch Response Latency Boost
         var touchBoostOk = false
         if (settingsRepository.touchBoost.value) {
-            // Universal Android touch response speed knob
             val touchRes = shizukuManager.executeCommandWithResult("settings put system touch_response_speed 2")
             touchBoostOk = touchRes?.exitCode == 0
-            // NOTE: Ghost key 'com.vivo.vtouch.persist' purged to eliminate redundant IPC overhead.
+            FrameXLog.i("Touch response latency boost applied: ok=$touchBoostOk", tag = TAG)
         }
 
         // 6. Vivo Whitelist Injection (Safe CSV Append)
-        var whitelistAppliedOk = false
         if (isVivo) {
-            if (!packageName.isNullOrBlank()) {
+            val whitelistAppliedOk = if (!packageName.isNullOrBlank()) {
                 var allSucceeded = true
                 for (key in vivoWhitelistKeys) {
                     val currentValRes = shizukuManager.executeCommandWithResult("settings get global $key")
@@ -208,11 +216,12 @@ class EsportsOptimizationEngine @Inject constructor(
                         val newList = pkgs.joinToString(",")
                         val writeRes = shizukuManager.executeCommandWithResult("settings put global $key \"$newList\"")
                         if (writeRes?.exitCode != 0) allSucceeded = false
+                        FrameXLog.i("Vivo Whitelist key '$key' updated with $packageName (exitCode=${writeRes?.exitCode})", tag = TAG)
                     }
                 }
-                whitelistAppliedOk = allSucceeded
+                allSucceeded
             } else {
-                whitelistAppliedOk = true
+                true
             }
 
             _vivoOptimizationResult.value = VivoOptimizationResult(
@@ -221,13 +230,15 @@ class EsportsOptimizationEngine @Inject constructor(
                 touchBoost = touchBoostOk,
                 whitelistApplied = whitelistAppliedOk
             )
+            FrameXLog.i("Vivo Optimization result summary: displayModeLock=$displayModeLockOk, maxHz=${maxHz.toInt()}, touchBoost=$touchBoostOk, whitelistApplied=$whitelistAppliedOk", tag = TAG)
         }
 
         return true
     }
 
-    suspend fun revertOptimizations() {
-        if (!shizukuManager.isShizukuAvailable.value || !shizukuManager.hasPermission.value) return
+    suspend fun revertOptimizations(): Boolean {
+        if (!shizukuManager.isShizukuAvailable.value || !shizukuManager.hasPermission.value) return false
+        FrameXLog.i("Reverting Esports Optimizations...", tag = TAG)
 
         recoverThermalOverrideIfNeeded()
 
@@ -235,11 +246,12 @@ class EsportsOptimizationEngine @Inject constructor(
         if (snapshot == null) {
             FrameXLog.w("No snapshot found, performing legacy revert", tag = TAG)
             revertLegacy()
-            return
+            return true
         }
 
         val pkg = snapshot.activeGamePackage
         val uid = snapshot.activeGameUid
+        FrameXLog.i("Reverting optimizations for pkg=$pkg, uid=$uid from snapshot", tag = TAG)
 
         // Revert per-app overrides
         if (pkg != null) {
@@ -248,6 +260,7 @@ class EsportsOptimizationEngine @Inject constructor(
                 shizukuManager.executeCommand("cmd activity set-bg-restriction-level --user 0 $pkg adaptive_bucket")
                 shizukuManager.executeCommand("am set-standby-bucket --user 0 $pkg working_set")
             }
+            FrameXLog.i("Per-app game & CPU priority overrides reset for $pkg", tag = TAG)
         }
 
         if (uid != null && settingsRepository.networkFirewall.value) {
@@ -258,6 +271,7 @@ class EsportsOptimizationEngine @Inject constructor(
         }
         shizukuManager.executeCommand("cmd deviceidle unforce")
         shizukuManager.executeCommand("cmd power set-fixed-performance-mode-enabled false")
+        FrameXLog.i("Network policy, deviceidle & fixed performance mode reset", tag = TAG)
 
         // Restore system display & touch settings
         snapshot.minRefreshRate?.let { restoreSetting("system", "min_refresh_rate", it) }
@@ -268,8 +282,10 @@ class EsportsOptimizationEngine @Inject constructor(
         snapshot.userPreferredDisplayModeId?.let { setting ->
             if (setting.existed && setting.value.isNotBlank()) {
                 shizukuManager.executeCommand("settings put secure user_preferred_display_mode_id ${setting.value}")
+                FrameXLog.i("Restored secure user_preferred_display_mode_id to ${setting.value}", tag = TAG)
             } else {
                 shizukuManager.executeCommand("settings put secure user_preferred_display_mode_id -1")
+                FrameXLog.i("Restored secure user_preferred_display_mode_id to -1", tag = TAG)
             }
         }
 
@@ -282,16 +298,20 @@ class EsportsOptimizationEngine @Inject constructor(
             stripPackageFromCsv("speed_mode_apps", pkg, snapshot.speedModeApps)
             stripPackageFromCsv("vivo_high_refresh_rate_apps", pkg, snapshot.vivoHighRefreshApps)
             stripPackageFromCsv("vivo_screen_refresh_rate_apps_list", pkg, snapshot.vivoScreenRefreshAppsList)
+            FrameXLog.i("Stripped $pkg from Vivo CSV whitelists", tag = TAG)
         } else {
             snapshot.gameCubeApps?.let { restoreSetting("global", "game_cube_apps", it) }
             snapshot.speedModeApps?.let { restoreSetting("global", "speed_mode_apps", it) }
             snapshot.vivoHighRefreshApps?.let { restoreSetting("global", "vivo_high_refresh_rate_apps", it) }
             snapshot.vivoScreenRefreshAppsList?.let { restoreSetting("global", "vivo_screen_refresh_rate_apps_list", it) }
+            FrameXLog.i("Restored Vivo CSV whitelists to snapshot baseline", tag = TAG)
         }
 
         // Clear snapshot only after successful restoration
         settingsRepository.clearGamingOptimizationSnapshot()
         _vivoOptimizationResult.value = null
+        FrameXLog.i("Snapshot cleared. Esports revert complete!", tag = TAG)
+        return true
     }
 
     private suspend fun restoreSetting(namespace: String, key: String, setting: SettingValue) {

--- a/app/src/main/java/com/framex/app/gaming/GamingModeEngine.kt
+++ b/app/src/main/java/com/framex/app/gaming/GamingModeEngine.kt
@@ -177,6 +177,15 @@ class GamingModeEngine @Inject constructor(
         }.sortedBy { it.label.lowercase() }
     }
 
+    private fun isPackageInstalled(pkg: String): Boolean {
+        return try {
+            context.packageManager.getApplicationInfo(pkg, 0)
+            true
+        } catch (_: PackageManager.NameNotFoundException) {
+            false
+        }
+    }
+
     /**
      * Full Gaming Mode activation sequence.
      *
@@ -192,6 +201,7 @@ class GamingModeEngine @Inject constructor(
         }
 
         _state.value = GamingModeState.Enabling(0f, "Initializing…")
+        com.framex.app.utils.FrameXLog.i("Starting Gaming Mode activation (activeGamePkg=$activeGamePkg)...", tag = "GamingMode")
         
         val prefs = context.getSharedPreferences("framex_settings", Context.MODE_PRIVATE)
         val audioManager = context.getSystemService(Context.AUDIO_SERVICE) as AudioManager
@@ -213,8 +223,9 @@ class GamingModeEngine @Inject constructor(
             val targetVol = (targetVolPct / 100f * maxVol).toInt().coerceIn(0, maxVol)
             try {
                 audioManager.setStreamVolume(AudioManager.STREAM_RING, targetVol, 0)
+                com.framex.app.utils.FrameXLog.i("Ringtone volume set to $targetVol/$maxVol (original: $currentVol)", tag = "GamingMode")
             } catch (e: Exception) {
-                com.framex.app.utils.FrameXLog.w("Failed to set ringtone volume", e)
+                com.framex.app.utils.FrameXLog.w("Failed to set ringtone volume", e, tag = "GamingMode")
             }
 
             // Settings Overrides (auto-brightness, auto-rotate)
@@ -225,6 +236,7 @@ class GamingModeEngine @Inject constructor(
                     val origBrightnessMode = Settings.System.getInt(context.contentResolver, Settings.System.SCREEN_BRIGHTNESS_MODE, Settings.System.SCREEN_BRIGHTNESS_MODE_AUTOMATIC)
                     prefs.edit().putInt("orig_brightness_mode", origBrightnessMode).apply()
                     Settings.System.putInt(context.contentResolver, Settings.System.SCREEN_BRIGHTNESS_MODE, Settings.System.SCREEN_BRIGHTNESS_MODE_MANUAL)
+                    com.framex.app.utils.FrameXLog.i("Screen brightness mode set to MANUAL (original mode: $origBrightnessMode)", tag = "GamingMode")
                 }
 
                 // Rotation override
@@ -232,6 +244,7 @@ class GamingModeEngine @Inject constructor(
                     val origRotation = Settings.System.getInt(context.contentResolver, Settings.System.ACCELEROMETER_ROTATION, 1)
                     prefs.edit().putInt("orig_rotation_mode", origRotation).apply()
                     Settings.System.putInt(context.contentResolver, Settings.System.ACCELEROMETER_ROTATION, 0) // Lock orientation
+                    com.framex.app.utils.FrameXLog.i("Auto-rotation locked to 0 (original: $origRotation)", tag = "GamingMode")
                 }
             }
         }
@@ -242,8 +255,9 @@ class GamingModeEngine @Inject constructor(
             // Phase 0 — Deep Cache Purge (Instantly clear system caches to free RAM block)
             try {
                 shizukuManager.executeCommand("pm trim-caches 4G")
+                com.framex.app.utils.FrameXLog.i("Deep RAM cache purge (pm trim-caches 4G) completed", tag = "GamingMode")
             } catch (e: Exception) {
-                com.framex.app.utils.FrameXLog.w("Deep cache purge failed", e)
+                com.framex.app.utils.FrameXLog.w("Deep cache purge failed", e, tag = "GamingMode")
             }
         }
         
@@ -272,23 +286,27 @@ class GamingModeEngine @Inject constructor(
 
         try {
             val affectedPkgs = mutableSetOf<String>()
+            val installedSafeToSuspend = SAFE_TO_SUSPEND.filter { isPackageInstalled(it) }
 
             if (boostRam && !isAlreadyActive) {
                 // ----------------------------------------------------------------
                 // Phase 1 & 2 — Batch Suspend OEM, Google, and User Apps
                 // ----------------------------------------------------------------
-                val googleTargets = GOOGLE_SAFE_TO_SUSPEND.filter { it !in finalWhitelist }
+                val googleTargets = GOOGLE_SAFE_TO_SUSPEND.filter { it !in finalWhitelist && isPackageInstalled(it) }
                 val userApps = withContext(Dispatchers.IO) { getInstalledUserApps() }
                     .filter { it.packageName !in finalWhitelist }
                 val userTargets = userApps.map { it.packageName }
 
-                val allTargets = (SAFE_TO_SUSPEND + googleTargets + userTargets).distinct()
+                val allTargets = (installedSafeToSuspend + googleTargets + userTargets).distinct()
+                com.framex.app.utils.FrameXLog.i("Suspending ${allTargets.size} background apps (safe: ${installedSafeToSuspend.size}, google: ${googleTargets.size}, user: ${userTargets.size})...", tag = "GamingMode")
 
                 _state.value = GamingModeState.Enabling(0.5f, "Suspending ${allTargets.size} background apps…")
-                shizukuManager.suspendPackages(allTargets, true)
+                val suspendResult = shizukuManager.suspendPackages(allTargets, true)
+                val failedPkgs = suspendResult?.failedPackages?.toSet().orEmpty()
 
-                affectedPkgs.addAll(googleTargets)
-                affectedPkgs.addAll(userTargets)
+                affectedPkgs.addAll(googleTargets.filter { it !in failedPkgs })
+                affectedPkgs.addAll(userTargets.filter { it !in failedPkgs })
+                com.framex.app.utils.FrameXLog.i("Package suspension finished: ${affectedPkgs.size} apps successfully suspended, ${failedPkgs.size} failed", tag = "GamingMode")
             }
 
             // Persist the affected list so disableGamingMode restores only what we changed.
@@ -302,6 +320,7 @@ class GamingModeEngine @Inject constructor(
                 // ----------------------------------------------------------------
                 _state.value = GamingModeState.Enabling(0.96f, "Purging background cache…")
                 shizukuManager.executeCommand("am kill-all")
+                com.framex.app.utils.FrameXLog.i("Background process purge (am kill-all) executed", tag = "GamingMode")
             }
 
             // ----------------------------------------------------------------
@@ -311,31 +330,27 @@ class GamingModeEngine @Inject constructor(
                 val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
                 if (nm.isNotificationPolicyAccessGranted) {
                     nm.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_NONE)
+                    com.framex.app.utils.FrameXLog.i("DND filter set to INTERRUPTION_FILTER_NONE", tag = "GamingMode")
                 }
             }
 
-            // Apply Esports optimizations for all activations.
-            // When activeGamePkg is null (manual activation), package-specific commands like
-            // cmd game set --fps are skipped, but all system-wide Vivo/thermal boosts still run.
-            // Apply Esports optimizations for all activations.
-            // When activeGamePkg is null (manual activation), package-specific commands like
-            // cmd game set --fps are skipped, but all system-wide Vivo/thermal boosts still run.
             val optimizationsApplied = try {
                 val uid = activeGamePkg?.let {
                     runCatching { context.packageManager.getPackageUid(it, 0) }.getOrNull()
                 }
                 esportsOptimizationEngine.applyOptimizationsForGame(activeGamePkg, uid)
             } catch (e: Exception) {
-                com.framex.app.utils.FrameXLog.w("Esports optimization failed", e)
+                com.framex.app.utils.FrameXLog.w("Esports optimization failed", e, tag = "GamingMode")
                 false
             }
 
             if (!optimizationsApplied) {
                 // Esports snapshot capture failed, abort gaming mode activation
                 _state.value = GamingModeState.Error("Failed to capture system settings snapshot")
+                com.framex.app.utils.FrameXLog.e("Esports optimizations failed to apply, aborting activation", tag = "GamingMode")
                 // Clean up what we've done so far
                 if (!isAlreadyActive) {
-                    val allToUnsuspend = (SAFE_TO_SUSPEND + affectedPkgs).distinct()
+                    val allToUnsuspend = (installedSafeToSuspend + affectedPkgs).distinct()
                     shizukuManager.suspendPackages(allToUnsuspend, false)
                 }
                 settingsRepository.setGamingModeActive(false)
@@ -343,19 +358,19 @@ class GamingModeEngine @Inject constructor(
                 return
             }
 
-            // Update snapshot with affected packages (now that suspension is complete)
-            val currentSnapshot = settingsRepository.loadGamingOptimizationSnapshot()
-            currentSnapshot?.let { snapshot ->
-                val updatedSnapshot = snapshot.copy(affectedPackages = affectedPkgs)
-                settingsRepository.saveGamingOptimizationSnapshot(updatedSnapshot)
+            // Update snapshot with affected packages (only if we suspended new packages)
+            if (!isAlreadyActive || affectedPkgs.isNotEmpty()) {
+                val currentSnapshot = settingsRepository.loadGamingOptimizationSnapshot()
+                currentSnapshot?.let { snapshot ->
+                    val updatedSnapshot = snapshot.copy(affectedPackages = affectedPkgs)
+                    settingsRepository.saveGamingOptimizationSnapshot(updatedSnapshot)
+                }
             }
 
-            // ----------------------------------------------------------------
-            // Done
-            // ----------------------------------------------------------------
             settingsRepository.setGamingModeActive(true)
             _isActive.value = true
             _state.value = GamingModeState.Active
+            com.framex.app.utils.FrameXLog.i("Gaming Mode activation complete! Active game: $activeGamePkg", tag = "GamingMode")
 
         } catch (e: Exception) {
             _state.value = GamingModeState.Error(e.message ?: "Unexpected error during activation")
@@ -374,23 +389,47 @@ class GamingModeEngine @Inject constructor(
      */
     suspend fun disableGamingMode() {
         _state.value = GamingModeState.Disabling
+        com.framex.app.utils.FrameXLog.i("Starting Gaming Mode deactivation...", tag = "GamingMode")
 
         try {
             // Load snapshot to get affected packages
             val snapshot = settingsRepository.loadGamingOptimizationSnapshot()
             val affectedUserPkgs = snapshot?.affectedPackages ?: settingsRepository.getGamingAffectedPackages()
-            val allToUnsuspend = (SAFE_TO_SUSPEND + affectedUserPkgs).distinct()
+            val installedSafeToSuspend = SAFE_TO_SUSPEND.filter { isPackageInstalled(it) }
+            val allToUnsuspend = (installedSafeToSuspend + affectedUserPkgs).distinct()
 
-            shizukuManager.suspendPackages(allToUnsuspend, false)
+            com.framex.app.utils.FrameXLog.i("Attempting to unsuspend ${allToUnsuspend.size} packages (safe: ${installedSafeToSuspend.size}, user: ${affectedUserPkgs.size})...", tag = "GamingMode")
+            val suspendResult = shizukuManager.suspendPackages(allToUnsuspend, false)
+            if (suspendResult == null) {
+                com.framex.app.utils.FrameXLog.e("Deactivation failed: Shizuku IPC binder unavailable", tag = "GamingMode")
+                _state.value = GamingModeState.Error("Deactivation incomplete: Shizuku service unavailable. Tap to retry.")
+                return
+            }
+
+            val failedPkgs = suspendResult.failedPackages?.toSet().orEmpty()
+            if (failedPkgs.isNotEmpty()) {
+                com.framex.app.utils.FrameXLog.w("Deactivation partial failure: ${failedPkgs.size}/${allToUnsuspend.size} packages failed to unsuspend: $failedPkgs", tag = "GamingMode")
+                val failedUserPkgs = failedPkgs.filter { it !in SAFE_TO_SUSPEND }.toSet()
+                settingsRepository.setGamingAffectedPackages(failedUserPkgs)
+                snapshot?.let {
+                    settingsRepository.saveGamingOptimizationSnapshot(it.copy(affectedPackages = failedUserPkgs))
+                }
+                _state.value = GamingModeState.Error("Deactivation incomplete: ${failedPkgs.size} apps still suspended. Tap to retry.")
+                return
+            }
+
+            com.framex.app.utils.FrameXLog.i("Package unsuspension completed successfully (${allToUnsuspend.size} packages unsuspended)", tag = "GamingMode")
             settingsRepository.setGamingAffectedPackages(emptySet())
 
             // Purge spawned background processes after unsuspending to prevent Vivo PEM battery drain
             shizukuManager.executeCommand("am kill-all")
+            com.framex.app.utils.FrameXLog.i("Background process purge (am kill-all) executed", tag = "GamingMode")
 
             // Restore DND
             val nm = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             if (nm.isNotificationPolicyAccessGranted) {
                 nm.setInterruptionFilter(NotificationManager.INTERRUPTION_FILTER_ALL)
+                com.framex.app.utils.FrameXLog.i("DND filter restored to INTERRUPTION_FILTER_ALL", tag = "GamingMode")
             }
 
             // Restore original settings/overrides
@@ -402,8 +441,9 @@ class GamingModeEngine @Inject constructor(
             if (origVol != -1) {
                 try {
                     audioManager.setStreamVolume(AudioManager.STREAM_RING, origVol, 0)
+                    com.framex.app.utils.FrameXLog.i("Ringtone volume restored to $origVol", tag = "GamingMode")
                 } catch (e: Exception) {
-                    com.framex.app.utils.FrameXLog.w("Failed to restore ringtone volume", e)
+                    com.framex.app.utils.FrameXLog.w("Failed to restore ringtone volume", e, tag = "GamingMode")
                 }
                 prefs.edit().remove("orig_ringtone_val").apply()
             }
@@ -414,26 +454,37 @@ class GamingModeEngine @Inject constructor(
                 if (origMode != -1) {
                     Settings.System.putInt(context.contentResolver, Settings.System.SCREEN_BRIGHTNESS_MODE, origMode)
                     prefs.edit().remove("orig_brightness_mode").apply()
+                    com.framex.app.utils.FrameXLog.i("Screen brightness mode restored to $origMode", tag = "GamingMode")
                 }
                 val origRotate = prefs.getInt("orig_rotation_mode", -1)
                 if (origRotate != -1) {
                     Settings.System.putInt(context.contentResolver, Settings.System.ACCELEROMETER_ROTATION, origRotate)
                     prefs.edit().remove("orig_rotation_mode").apply()
+                    com.framex.app.utils.FrameXLog.i("Auto-rotation mode restored to $origRotate", tag = "GamingMode")
                 }
             }
 
-        } catch (e: Exception) {
-            com.framex.app.utils.FrameXLog.w("Error during Gaming Mode deactivation", e)
-        } finally {
-            try {
+            val revertSuccess = try {
                 esportsOptimizationEngine.revertOptimizations()
             } catch (e: Exception) {
-                com.framex.app.utils.FrameXLog.w("Esports optimization cleanup failed", e)
+                com.framex.app.utils.FrameXLog.w("Esports optimization cleanup failed", e, tag = "GamingMode")
+                false
+            }
+
+            if (revertSuccess) {
+                com.framex.app.utils.FrameXLog.i("Esports optimizations reverted successfully", tag = "GamingMode")
+            } else {
+                com.framex.app.utils.FrameXLog.w("Esports revert incomplete during deactivation", tag = "GamingMode")
             }
 
             settingsRepository.setGamingModeActive(false)
             _isActive.value = false
             _state.value = GamingModeState.Idle
+            com.framex.app.utils.FrameXLog.i("Gaming Mode deactivation complete!", tag = "GamingMode")
+
+        } catch (e: Exception) {
+            com.framex.app.utils.FrameXLog.w("Error during Gaming Mode deactivation", e, tag = "GamingMode")
+            _state.value = GamingModeState.Error(e.message ?: "Unexpected error during deactivation")
         }
     }
 

--- a/app/src/main/java/com/framex/app/shizuku/CommandRunnerService.kt
+++ b/app/src/main/java/com/framex/app/shizuku/CommandRunnerService.kt
@@ -325,8 +325,14 @@ class CommandRunnerService private constructor(
         return null
     }
 
-    override fun suspendPackages(packageNames: Array<out String>?, suspended: Boolean): Int {
-        if (packageNames.isNullOrEmpty()) return 0
+    override fun suspendPackages(packageNames: Array<out String>?, suspended: Boolean): SuspendResult {
+        val failed = mutableListOf<String>()
+        if (packageNames.isNullOrEmpty()) {
+            return SuspendResult().apply {
+                this.failedPackages = emptyArray()
+                this.successCount = 0
+            }
+        }
         var successCount = 0
         val action = if (suspended) "suspend" else "unsuspend"
         for (pkg in packageNames) {
@@ -334,9 +340,19 @@ class CommandRunnerService private constructor(
             val result = executeCommandWithResult(cmd)
             if (result.exitCode == 0) {
                 successCount++
+            } else {
+                val output = result.output.lowercase()
+                if (output.contains("unknown target package") || output.contains("does not exist") || output.contains("not found")) {
+                    com.framex.app.utils.FrameXLog.d("Skipping uninstalled package $pkg during $action", tag = "CmdRunner")
+                } else {
+                    failed.add(pkg)
+                }
             }
         }
-        return successCount
+        return SuspendResult().apply {
+            this.failedPackages = failed.toTypedArray()
+            this.successCount = successCount
+        }
     }
 
     override fun setAppOpMode(packageNames: Array<out String>?, opCode: Int, mode: Int): Int {

--- a/app/src/main/java/com/framex/app/shizuku/ShizukuManager.kt
+++ b/app/src/main/java/com/framex/app/shizuku/ShizukuManager.kt
@@ -117,13 +117,24 @@ class ShizukuManager @Inject constructor() {
         if (initialDelayMs > 0L) {
             kotlinx.coroutines.delay(initialDelayMs)
         }
-        connectUserService()
-        val deferred = pendingConnection ?: return commandRunner
-        val runner = withTimeoutOrNull(BIND_TIMEOUT_MS) { deferred.await() }
-        if (runner == null) {
+        
+        var attempts = 0
+        while (attempts < MAX_BIND_RETRIES) {
+            attempts++
+            connectUserService()
+            val deferred = pendingConnection ?: return commandRunner
+            val runner = withTimeoutOrNull(BIND_TIMEOUT_MS) { deferred.await() }
+            if (runner != null) {
+                return runner
+            }
+            com.framex.app.utils.FrameXLog.w("bindUserService attempt $attempts/$MAX_BIND_RETRIES timed out after ${BIND_TIMEOUT_MS}ms")
             disconnectUserService(remove = true)
+            if (attempts < MAX_BIND_RETRIES) {
+                kotlinx.coroutines.delay(BIND_RETRY_DELAY_MS)
+            }
         }
-        return runner
+        com.framex.app.utils.FrameXLog.w("CommandRunner unavailable after $MAX_BIND_RETRIES bind attempts")
+        return null
     }
 
     suspend fun executeCommand(command: String): String {
@@ -231,15 +242,15 @@ class ShizukuManager @Inject constructor() {
         }
     }
 
-    suspend fun suspendPackages(packageNames: List<String>, suspended: Boolean): Int {
+    suspend fun suspendPackages(packageNames: List<String>, suspended: Boolean): SuspendResult? {
         if (!_isShizukuAvailable.value || !_hasPermission.value || packageNames.isEmpty()) {
             com.framex.app.utils.FrameXLog.w("suspendPackages skipped: Shizuku unavailable/unpermitted or package list empty")
-            return 0
+            return null
         }
         return commandMutex.withLock {
             val runner = awaitCommandRunner() ?: run {
                 com.framex.app.utils.FrameXLog.w("CommandRunner unavailable after bind attempt in suspendPackages")
-                return@withLock 0
+                return@withLock null
             }
             try {
                 withContext(Dispatchers.IO) {
@@ -247,7 +258,7 @@ class ShizukuManager @Inject constructor() {
                 }
             } catch (e: Exception) {
                 com.framex.app.utils.FrameXLog.e("suspendPackages failed", e)
-                0
+                null
             }
         }
     }
@@ -353,7 +364,7 @@ class ShizukuManager @Inject constructor() {
 
     private fun userServiceArgs() = Shizuku.UserServiceArgs(
         ComponentName("com.framex.app", CommandRunnerService::class.java.name)
-    ).daemon(false)
+    ).daemon(true)
         .tag(USER_SERVICE_TAG)
         .version(BuildConfig.VERSION_CODE)
         .processNameSuffix("runner")
@@ -362,6 +373,8 @@ class ShizukuManager @Inject constructor() {
         const val REQUEST_CODE_PERMISSION = 1001
         private const val BIND_TIMEOUT_MS = 5000L
         private const val INITIAL_BIND_DELAY_MS = 2000L
+        private const val MAX_BIND_RETRIES = 3
+        private const val BIND_RETRY_DELAY_MS = 500L
         private const val USER_SERVICE_TAG = "framex-command-runner"
         private const val COMMAND_EXECUTION_FAILED = -1
     }


### PR DESCRIPTION
## Summary & Problem Statement
This PR resolves background app unsuspension failures and state desynchronization during Gaming Mode deactivation after extended gaming sessions (Issue #66).

### Root Causes Addressed
1. **IPC Process LMK Death:** `ShizukuManager` passed `.daemon(false)` in `UserServiceArgs`, allowing Android's Low Memory Killer (LMK) to kill `CommandRunnerService` in the background during 15–60 minute gaming sessions. Upon returning to FrameX, the binder connection was stale/null.
2. **Snapshot Overwriting on Game Launch:** When launching a game from the Game Launcher while Gaming Mode was already active (`isAlreadyActive = true`), `enableGamingMode()` was updating the snapshot with `affectedPkgs = []`. This erased the 34 suspended user packages from snapshot memory, causing `disableGamingMode()` to attempt unsuspending `0` user apps.
3. **Unconditional State Clearance:** `disableGamingMode()` ignored whether `suspendPackages()` succeeded or failed. Its `finally` block unconditionally wiped `affectedPackages` and deleted `GamingOptimizationSnapshot`, claiming deactivation succeeded while leaving user apps frozen as `suspended=true` on the OS level.
4. **Uninstalled Package Error Blocking:** Absent/uninstalled packages in `SAFE_TO_SUSPEND` returned exit code `1` (`Unknown target package`), which was mistakenly treated as a critical failure that aborted deactivation early.

---

## Key Changes

### Shizuku & IPC Layer
- **`SuspendResult.aidl` & `ICommandRunner.aidl`**: Upgraded `suspendPackages` AIDL contract to return a `SuspendResult` containing explicit arrays of `failedPackages` and `successCount`.
- **`CommandRunnerService.kt`**: Updated package suspension logic to ignore `Unknown target package` error outputs so uninstalled bloatware is not counted as a failure.
- **`ShizukuManager.kt`**: Enabled `.daemon(true)` on `UserServiceArgs` to keep `CommandRunnerService` alive under Shizuku's privileged UID across long games, and added bounded retries in `awaitCommandRunner()`.

### Gaming & Optimization Engines
- **`GamingModeEngine.kt`**:
  - Re-architected `disableGamingMode()` to perform verified transactional deactivation. FrameX verifies `suspendResult` and will retain snapshot/state and surface `GamingModeState.Error(...)` if any packages fail to unsuspend.
  - Fixed snapshot updating in `enableGamingMode()` so launching a game from the launcher while active (`isAlreadyActive = true`) preserves `snapshot.affectedPackages`.
  - Added `isPackageInstalled()` pre-filtering for `SAFE_TO_SUSPEND` and `GOOGLE_SAFE_TO_SUSPEND`.
- **`EsportsOptimizationEngine.kt`**: Updated `captureSnapshot()` to load and preserve existing `affectedPackages`, and made `revertOptimizations()` return a `Boolean` status.
- **Step-by-Step Logging**: Added explicit execution logging across activation and deactivation pipelines.

---

## Verification Results

### On-Device Verification (Vivo V2426 - 16)
- **13+ Minute Extended Gaming Test:** Activated Gaming Mode, launched PUBG Mobile (`com.pubg.imobile`) from launcher, played for 13+ minutes, and deactivated.
- **Unsuspension Outcome:** **58 / 58 packages** (24 safe bloat + 34 user apps) unsuspended 100% successfully in 1.9s.
- **Revert Verification:** Display refresh rate (`user_preferred_display_mode_id`), CPU priority, network firewall, Doze exemptions, and all 4 Vivo whitelist CSV entries were completely restored to baseline.
