### PR TITLE
fix(thermal, metrics): align GPU graph series, background polling & ping timeout state

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,8 +13,8 @@ android {
         applicationId = "com.framex.app"
         minSdk = 26
         targetSdk = 34
-        versionCode = 26
-        versionName = "1.5.20"
+        versionCode = 27
+        versionName = "1.5.21"
     }
 
     buildFeatures {

--- a/app/src/main/java/com/framex/app/metrics/MetricModule.kt
+++ b/app/src/main/java/com/framex/app/metrics/MetricModule.kt
@@ -119,7 +119,11 @@ fun metricValueFor(id: MetricModuleId, metricsState: MetricsState): String = whe
             String.format("%.0f KB/s", totalKbps)
         }
     }
-    MetricModuleId.PING -> if (metricsState.pingMs > 0) "${metricsState.pingMs} ms" else "-- ms"
+    MetricModuleId.PING -> when (metricsState.pingReadStatus) {
+        MetricReadStatus.Ok -> "${metricsState.pingMs} ms"
+        MetricReadStatus.Loading -> "-- ms"
+        else -> "timeout"
+    }
 }
 
 /** Short label for the overlay's compact/minimal display — full names are used in

--- a/app/src/main/java/com/framex/app/metrics/MetricsEngine.kt
+++ b/app/src/main/java/com/framex/app/metrics/MetricsEngine.kt
@@ -28,6 +28,7 @@ data class MetricsState(
     val networkRxKbps: Float = 0f,
     val networkTxKbps: Float = 0f,
     val pingMs: Int = 0,
+    val pingReadStatus: MetricReadStatus = MetricReadStatus.Loading,
     // Full thermal breakdown — see ThermalMonitor.ThermalState for field meaning.
     val thermalCpuC: Float = 0f,
     val thermalGpuC: Float = 0f,
@@ -203,8 +204,11 @@ class MetricsEngine @Inject constructor(
                     }
                 }
                 toggleModule("ping", enabled) {
-                    pingMonitor.ping.collect {
-                        _metricsState.value = _metricsState.value.copy(pingMs = it)
+                    pingMonitor.ping.collect { p ->
+                        _metricsState.value = _metricsState.value.copy(
+                            pingMs = p.pingMs,
+                            pingReadStatus = p.readStatus
+                        )
                     }
                 }
                 toggleModule("top_process", enabled) {
@@ -247,7 +251,7 @@ class MetricsEngine @Inject constructor(
                     hasThermalCpu = false, hasThermalGpu = false, hasThermalNpu = false,
                     hasThermalSkin = false, hasThermalBattery = false
                 )
-                "ping"    -> _metricsState.value.copy(pingMs = 0)
+                "ping"    -> _metricsState.value.copy(pingMs = 0, pingReadStatus = MetricReadStatus.Loading)
                 "top_process" -> _metricsState.value.copy(
                     topProcessName = null, topProcessCpuPercent = 0f,
                     topProcessReadStatus = MetricReadStatus.Loading

--- a/app/src/main/java/com/framex/app/metrics/MetricsEngine.kt
+++ b/app/src/main/java/com/framex/app/metrics/MetricsEngine.kt
@@ -133,8 +133,15 @@ class MetricsEngine @Inject constructor(
         engineScope.launch {
             combine(
                 settingsRepository.enabledModules,
-                screenOverrideModules
-            ) { persisted, override -> persisted + override }
+                screenOverrideModules,
+                settingsRepository.isGamingModeActiveFlow
+            ) { persisted, override, gamingActive ->
+                if (gamingActive) {
+                    persisted + override + setOf("temp", "thermal")
+                } else {
+                    persisted + override
+                }
+            }
                 .collect { enabled ->
                 toggleModule("cpu", enabled) {
                     coroutineScope {

--- a/app/src/main/java/com/framex/app/metrics/Monitors.kt
+++ b/app/src/main/java/com/framex/app/metrics/Monitors.kt
@@ -528,6 +528,11 @@ class ThermalMonitor @Inject constructor(
     }
 }
 
+data class PingResult(
+    val pingMs: Int,
+    val readStatus: MetricReadStatus
+)
+
 @Singleton
 class PingMonitor @Inject constructor(
     private val shizukuManager: ShizukuManager
@@ -537,11 +542,11 @@ class PingMonitor @Inject constructor(
         private const val POLL_INTERVAL_MS = 2_000L
     }
 
-    val ping: Flow<Int> = flow {
+    val ping: Flow<PingResult> = flow {
         while (true) {
             val output = if (shizukuManager.isShizukuAvailable.value && shizukuManager.hasPermission.value) {
                 try {
-                    shizukuManager.executeCommand("ping -c 1 8.8.8.8")
+                    shizukuManager.executeCommand("ping -c 1 -w 2 8.8.8.8")
                 } catch (e: Exception) {
                     executePing()
                 }
@@ -549,20 +554,33 @@ class PingMonitor @Inject constructor(
                 executePing()
             }
 
-            val pingMs = if (output.contains("time=")) {
-                output.split("time=").getOrNull(1)
-                    ?.split(" ")?.getOrNull(0)
-                    ?.toFloatOrNull()
-                    ?.roundToInt() ?: 0
-            } else 0
-            emit(pingMs)
+            val result = parsePingOutput(output)
+            emit(result)
             delay(POLL_INTERVAL_MS)
+        }
+    }
+
+    private fun parsePingOutput(output: String): PingResult {
+        if (output.isBlank()) return PingResult(0, MetricReadStatus.EmptyOutput)
+        
+        return if (output.contains("time=")) {
+            val ms = output.split("time=").getOrNull(1)
+                ?.split(" ")?.getOrNull(0)
+                ?.toFloatOrNull()
+                ?.roundToInt() ?: 0
+            if (ms > 0) {
+                PingResult(ms, MetricReadStatus.Ok)
+            } else {
+                PingResult(0, MetricReadStatus.ParseFailed)
+            }
+        } else {
+            PingResult(0, MetricReadStatus.NoData)
         }
     }
 
     private fun executePing(): String {
         return try {
-            val process = Runtime.getRuntime().exec("ping -c 1 8.8.8.8")
+            val process = Runtime.getRuntime().exec("ping -c 1 -w 2 8.8.8.8")
             try {
                 process.inputStream.bufferedReader().use { it.readText() }
             } finally {

--- a/app/src/main/java/com/framex/app/overlay/OverlayManager.kt
+++ b/app/src/main/java/com/framex/app/overlay/OverlayManager.kt
@@ -299,7 +299,6 @@ fun OverlayContent(
     metricsState: com.framex.app.metrics.MetricsState,
     onDrag: (Float, Float) -> Unit,
     onDragEnd: () -> Unit = {},
-    onModeToggle: () -> Unit = {}
 ) {
     com.framex.app.ui.components.OverlayPreviewContent(
         mode = mode,

--- a/app/src/main/java/com/framex/app/repository/SettingsRepository.kt
+++ b/app/src/main/java/com/framex/app/repository/SettingsRepository.kt
@@ -215,9 +215,13 @@ class SettingsRepository @Inject constructor(
         setGamingModeWhitelist(current)
     }
 
+    private val _isGamingModeActiveFlow = MutableStateFlow(prefs.getBoolean(KEY_GAMING_MODE_ACTIVE, false))
+    val isGamingModeActiveFlow: StateFlow<Boolean> = _isGamingModeActiveFlow.asStateFlow()
+
     /** Whether Gaming Mode was active when the app was last killed. Used for recovery. */
     fun setGamingModeActive(active: Boolean) {
         prefs.edit().putBoolean(KEY_GAMING_MODE_ACTIVE, active).apply()
+        _isGamingModeActiveFlow.value = active
     }
 
     fun isGamingModeActive(): Boolean = prefs.getBoolean(KEY_GAMING_MODE_ACTIVE, false)

--- a/app/src/main/java/com/framex/app/ui/screens/thermal/ThermalDiagnosticsModels.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/thermal/ThermalDiagnosticsModels.kt
@@ -16,7 +16,7 @@ enum class GraphMetricMode(val label: String) {
     FPS_THERMAL("FPS vs Thermal (CPU + Skin)"),
     FPS_JANK("FPS + Jank Frames"),
     FPS_ONLY("FPS Only"),
-    THERMAL_ONLY("Thermal Only (CPU, GPU, Skin)"),
+    THERMAL_ONLY("Thermal Only (CPU, GPU, Skin, Battery)"),
     FPS_TOP_PROCESS("FPS + Top Process CPU%")
 }
 

--- a/app/src/main/java/com/framex/app/ui/screens/thermal/ThermalDiagnosticsScreen.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/thermal/ThermalDiagnosticsScreen.kt
@@ -493,7 +493,8 @@ fun ThermalDiagnosticsScreen(
                     val tempRef = (filteredSnapshots.map { it.state.thermalCpuC } + filteredSnapshots.map { it.state.thermalSkinC })
                         .maxOrNull()?.coerceAtLeast(40f) ?: 80f
                     val jankRef = (filteredSnapshots.maxOfOrNull { it.state.jankyFrames.toFloat() } ?: 10f).coerceAtLeast(10f)
-                    seriesForMode(selectedGraphMode, fpsRef, tempRef, jankRef)
+                    val hasGpu = filteredSnapshots.any { it.state.hasThermalGpu || it.state.thermalGpuC > 0f }
+                    seriesForMode(selectedGraphMode, fpsRef, tempRef, jankRef, hasGpu = hasGpu)
                 }
                 GraphLegend(series = activeSeries, modifier = Modifier.padding(bottom = 10.dp))
 

--- a/app/src/main/java/com/framex/app/ui/screens/thermal/ThermalDiagnosticsUtils.kt
+++ b/app/src/main/java/com/framex/app/ui/screens/thermal/ThermalDiagnosticsUtils.kt
@@ -123,9 +123,16 @@ fun evaluateLikelyCause(
     }
 }
 
-fun seriesForMode(mode: GraphMetricMode, maxFps: Float, maxTemp: Float, maxJank: Float = 10f): List<GraphSeries> {
+fun seriesForMode(
+    mode: GraphMetricMode,
+    maxFps: Float,
+    maxTemp: Float,
+    maxJank: Float = 10f,
+    hasGpu: Boolean = true
+): List<GraphSeries> {
     val fpsSeries = GraphSeries("FPS", Color(0xFF38BDF8), "", maxFps, fillArea = true) { it.state.fps.toFloat() }
     val cpuSeries = GraphSeries("CPU", Color(0xFFFF2E4D), "°", maxTemp, fillArea = false) { it.state.thermalCpuC }
+    val gpuSeries = GraphSeries("GPU", Color(0xFF3B82F6), "°", maxTemp, fillArea = false) { it.state.thermalGpuC }
     val skinSeries = GraphSeries("Skin", Color(0xFFFFB703), "°", maxTemp, fillArea = false) { it.state.thermalSkinC }
     val batterySeries = GraphSeries("Battery", Color(0xFF06D6A0), "°", maxTemp, fillArea = false) { it.state.batteryTempC }
     val jankSeries = GraphSeries("Jank", Color(0xFFEF476F), "", maxJank, fillArea = false) { it.state.jankyFrames.toFloat() }
@@ -135,7 +142,13 @@ fun seriesForMode(mode: GraphMetricMode, maxFps: Float, maxTemp: Float, maxJank:
         GraphMetricMode.FPS_THERMAL -> listOf(cpuSeries, skinSeries, fpsSeries)
         GraphMetricMode.FPS_JANK -> listOf(jankSeries, fpsSeries)
         GraphMetricMode.FPS_ONLY -> listOf(fpsSeries)
-        GraphMetricMode.THERMAL_ONLY -> listOf(cpuSeries.copy(fillArea = true), skinSeries, batterySeries)
+        GraphMetricMode.THERMAL_ONLY -> {
+            val list = mutableListOf(cpuSeries.copy(fillArea = true))
+            if (hasGpu) list.add(gpuSeries)
+            list.add(skinSeries)
+            list.add(batterySeries)
+            list
+        }
         GraphMetricMode.FPS_TOP_PROCESS -> listOf(topProcessSeries, fpsSeries)
     }
 }


### PR DESCRIPTION
## Summary

- **Thermal Graph & Telemetry ([#65](https://github.com/MaheshSharan/FrameX-Android/issues/65#issuecomment-5132948396))**: Added `gpuSeries` with dynamic hardware detection (`hasGpu`), aligned `THERMAL_ONLY` label, and maintained background polling during Gaming Mode to prevent 0.0° flatlines.
- **Ping Timeout State ([#70](https://github.com/MaheshSharan/FrameX-Android/issues/70))**: Added `-w 2` deadline & `pingReadStatus` (`MetricReadStatus`) to display `timeout` on connection dropouts instead of misleading `-- ms`.
